### PR TITLE
Add support for multiple Elasticsearch nodes

### DIFF
--- a/outputs/elasticsearch/api.go
+++ b/outputs/elasticsearch/api.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Elasticsearch struct {
-	MaxRetries int
+	MaxRetries     int
 	connectionPool ConnectionPool
 	client         *http.Client
 }
@@ -63,7 +63,7 @@ func NewElasticsearch(urls []string, username string, password string) *Elastics
 	es := Elasticsearch{
 		connectionPool: connection_pool,
 		client:         &http.Client{},
-		MaxRetries: default_max_retries,
+		MaxRetries:     default_max_retries,
 	}
 	return &es
 }
@@ -121,7 +121,38 @@ func (es *Elasticsearch) SetMaxRetries(max_retries int) {
 	es.MaxRetries = max_retries
 }
 
-// Create a HTTP request to Elaticsearch
+// Send a HTTP Request to Elasticsearch. If it fails, mark the node as dead.
+// If it succeeds, mark it as alive and return the response.
+func (es *Elasticsearch) SendRequest(conn *Connection, req *http.Request) (*http.Response, error) {
+
+	req.Header.Add("Accept", "application/json")
+	if conn.Username != "" || conn.Password != "" {
+		req.SetBasicAuth(conn.Username, conn.Password)
+	}
+
+	resp, err := es.client.Do(req)
+	if err != nil {
+		// request fails
+		logp.Warn("Fail to send the request to Elasticsearch: %s", err)
+		es.connectionPool.MarkDead(conn)
+		return nil, err
+	}
+
+	if resp.StatusCode > 499 {
+		// request fails
+		es.connectionPool.MarkDead(conn)
+		return nil, fmt.Errorf("%d response from Elasticsearch", resp.StatusCode)
+	}
+
+	// request with success
+	es.connectionPool.MarkLive(conn)
+
+	return resp, nil
+
+}
+
+// Create an HTTP request and send it to Elasticsearch. The request is retransmitted max_retries
+// before returning an error.
 func (es *Elasticsearch) Request(method string, url string,
 	params map[string]string, body interface{}) (*http.Response, error) {
 
@@ -152,31 +183,16 @@ func (es *Elasticsearch) Request(method string, url string,
 
 		logp.Debug("elasticsearch", "Sending request to %s", url)
 
-		req.Header.Add("Accept", "application/json")
-		if conn.Username != "" || conn.Password != "" {
-			req.SetBasicAuth(conn.Username, conn.Password)
-		}
-
-		resp, err := es.client.Do(req)
+		resp, err := es.SendRequest(conn, req)
 		if err != nil {
-			// request fails
-			logp.Warn("Request fails: %s", err)
-			es.connectionPool.MarkDead(conn)
-			return nil, err
+			// retry
+			continue
 		}
-
-		if resp.StatusCode > 499 {
-			// request fails
-			es.connectionPool.MarkDead(conn)
-			return resp, fmt.Errorf("ES returned an error: %s", resp.Status)
-		}
-
-		// request with success
-		es.connectionPool.MarkLive(conn)
-
 		return resp, nil
 
 	}
+
+	logp.Warn("Request fails to be send after %d retries", es.MaxRetries)
 
 	return nil, fmt.Errorf("Request fails to be sent after %d retries", es.MaxRetries)
 }

--- a/outputs/elasticsearch/api.go
+++ b/outputs/elasticsearch/api.go
@@ -177,7 +177,7 @@ func (es *Elasticsearch) PerformRequest(conn *Connection, req *http.Request) ([]
 
 // Create an HTTP request and send it to Elasticsearch. The request is retransmitted max_retries
 // before returning an error.
-func (es *Elasticsearch) Request(method string, url string,
+func (es *Elasticsearch) Request(method string, path string,
 	params map[string]string, body interface{}) ([]byte, error) {
 
 	var errors []error
@@ -187,7 +187,7 @@ func (es *Elasticsearch) Request(method string, url string,
 		conn := es.connectionPool.GetConnection()
 		logp.Debug("elasticsearch", "Use connection %s", conn.Url)
 
-		url = conn.Url + url
+		url := conn.Url + path
 		if len(params) > 0 {
 			url = url + "?" + UrlEncode(params)
 		}

--- a/outputs/elasticsearch/api_mock_test.go
+++ b/outputs/elasticsearch/api_mock_test.go
@@ -148,3 +148,35 @@ func TestMultipleHosts(t *testing.T) {
 	}
 
 }
+
+func TestMultipleFailingHosts(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
+	}
+
+	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
+	body := map[string]interface{}{
+		"user":      "test",
+		"post_date": "2009-11-15T14:12:12",
+		"message":   "trying out",
+	}
+	server1 := ElasticsearchMock(503, []byte("Something went wrong"))
+	server2 := ElasticsearchMock(500, []byte("Something went wrong"))
+
+	logp.Debug("elasticsearch", "%s, %s", server1.URL, server2.URL)
+	es := NewElasticsearch([]string{server1.URL, server2.URL}, "", "")
+
+	params := map[string]string{
+		"refresh": "true",
+	}
+	_, err := es.Index(index, "test", "1", params, body)
+	if err == nil {
+		t.Errorf("Index() should return error.")
+	}
+
+	if !strings.Contains(err.Error(), "500 Internal Server Error") {
+		t.Errorf("Should return <500 Internal Server Error> instead of %v", err)
+	}
+
+}

--- a/outputs/elasticsearch/api_mock_test.go
+++ b/outputs/elasticsearch/api_mock_test.go
@@ -1,0 +1,117 @@
+package elasticsearch
+
+import (
+	"fmt"
+	"os"
+
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elastic/libbeat/logp"
+)
+
+func ElasticsearchMock(code int, body []byte) *httptest.Server {
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+		if body != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(body)
+		}
+	}))
+
+	return server
+}
+
+func TestOneHostSuccessResp(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
+	}
+
+	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
+	body := map[string]interface{}{
+		"user":      "test",
+		"post_date": "2009-11-15T14:12:12",
+		"message":   "trying out",
+	}
+	expected_resp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "test", Id: "1", Version: 1, Created: true})
+
+	server := ElasticsearchMock(200, expected_resp)
+
+	es := NewElasticsearch([]string{server.URL}, "", "")
+
+	params := map[string]string{
+		"refresh": "true",
+	}
+	resp, err := es.Index(index, "test", "1", params, body)
+	if err != nil {
+		t.Errorf("Index() returns error: %s", err)
+	}
+	if !resp.Created {
+		t.Errorf("Index() fails: %s", resp)
+	}
+}
+
+func TestOneHost500Resp(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
+	}
+
+	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
+	body := map[string]interface{}{
+		"user":      "test",
+		"post_date": "2009-11-15T14:12:12",
+		"message":   "trying out",
+	}
+
+	server := ElasticsearchMock(http.StatusInternalServerError, []byte("Something wrong happened"))
+
+	es := NewElasticsearch([]string{server.URL}, "", "")
+
+	params := map[string]string{
+		"refresh": "true",
+	}
+	_, err := es.Index(index, "test", "1", params, body)
+	if err == nil {
+		t.Errorf("Index() should return error.")
+	}
+
+	if !strings.Contains(err.Error(), "500 Internal Server Error") {
+		t.Errorf("Should return <500 Internal Server Error> instead of %v", err)
+	}
+}
+
+func TestOneHost503Resp(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
+	}
+
+	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
+	body := map[string]interface{}{
+		"user":      "test",
+		"post_date": "2009-11-15T14:12:12",
+		"message":   "trying out",
+	}
+
+	server := ElasticsearchMock(503, []byte("Something wrong happened"))
+
+	es := NewElasticsearch([]string{server.URL}, "", "")
+
+	params := map[string]string{
+		"refresh": "true",
+	}
+	_, err := es.Index(index, "test", "1", params, body)
+	if err == nil {
+		t.Errorf("Index() should return error.")
+	}
+
+	if !strings.Contains(err.Error(), "retries. Errors") {
+		t.Errorf("Should return <Request fails after 3 retries. Errors: > instead of %v", err)
+	}
+}

--- a/outputs/elasticsearch/api_test.go
+++ b/outputs/elasticsearch/api_test.go
@@ -20,7 +20,7 @@ func GetTestingElasticsearch() *Elasticsearch {
 		es_url = "http://localhost:9200"
 	}
 
-	return NewElasticsearch(es_url, "", "")
+	return NewElasticsearch([]string{es_url}, "", "")
 }
 
 func TestUrlEncode(t *testing.T) {

--- a/outputs/elasticsearch/bulkapi.go
+++ b/outputs/elasticsearch/bulkapi.go
@@ -38,7 +38,9 @@ func (es *Elasticsearch) Bulk(index string, doc_type string,
 		return nil, err
 	}
 
-	url := es.Url + path
+	conn := es.connectionPool.GetConnection()
+
+	url := conn.Url + path
 	if len(params) > 0 {
 		url = url + "?" + UrlEncode(params)
 	}
@@ -49,8 +51,8 @@ func (es *Elasticsearch) Bulk(index string, doc_type string,
 	}
 
 	req.Header.Add("Accept", "application/json")
-	if es.Username != "" || es.Password != "" {
-		req.SetBasicAuth(es.Username, es.Password)
+	if conn.Username != "" || conn.Password != "" {
+		req.SetBasicAuth(conn.Username, conn.Password)
 	}
 
 	resp, err := es.client.Do(req)

--- a/outputs/elasticsearch/bulkapi.go
+++ b/outputs/elasticsearch/bulkapi.go
@@ -32,8 +32,6 @@ func (es *Elasticsearch) BulkRequest(method string, path string,
 		return nil, nil
 	}
 
-	logp.Debug("elasticsearch", "Insert bulk messages:\n%s\n", buf)
-
 	for attempt := 0; attempt < es.MaxRetries; attempt++ {
 
 		conn := es.connectionPool.GetConnection()
@@ -43,13 +41,12 @@ func (es *Elasticsearch) BulkRequest(method string, path string,
 		if len(params) > 0 {
 			url = url + "?" + UrlEncode(params)
 		}
+		logp.Debug("elasticsearch", "Sending bulk request to %s", url)
 
 		req, err := http.NewRequest(method, url, &buf)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("NewRequest fails: %s", err)
 		}
-
-		logp.Debug("elasticsearch", "Sending bulk request to %s", url)
 
 		resp, err := es.PerformRequest(conn, req)
 		if err != nil {
@@ -60,6 +57,7 @@ func (es *Elasticsearch) BulkRequest(method string, path string,
 	}
 
 	logp.Warn("Request fails to be send after %d retries", es.MaxRetries)
+
 	return nil, fmt.Errorf("Request fails to be send after %d retries", es.MaxRetries)
 }
 

--- a/outputs/elasticsearch/bulkapi.go
+++ b/outputs/elasticsearch/bulkapi.go
@@ -11,7 +11,7 @@ import (
 	"github.com/elastic/libbeat/logp"
 )
 
-type BulkMsg struct {
+type EventMsg struct {
 	Ts    time.Time
 	Event common.MapStr
 }

--- a/outputs/elasticsearch/bulkapi.go
+++ b/outputs/elasticsearch/bulkapi.go
@@ -38,41 +38,57 @@ func (es *Elasticsearch) Bulk(index string, doc_type string,
 		return nil, err
 	}
 
-	conn := es.connectionPool.GetConnection()
+	for attempt := 0; attempt < es.MaxRetries; attempt++ {
 
-	url := conn.Url + path
-	if len(params) > 0 {
-		url = url + "?" + UrlEncode(params)
+		conn := es.connectionPool.GetConnection()
+		logp.Debug("elasticsearch", "Use connection %s", conn.Url)
+
+		url := conn.Url + path
+		if len(params) > 0 {
+			url = url + "?" + UrlEncode(params)
+		}
+
+		req, err := http.NewRequest("POST", url, &buf)
+		if err != nil {
+			return nil, err
+		}
+
+		logp.Debug("elasticsearch", "Sending bulk request to %s", url)
+
+		req.Header.Add("Accept", "application/json")
+		if conn.Username != "" || conn.Password != "" {
+			req.SetBasicAuth(conn.Username, conn.Password)
+		}
+
+		resp, err := es.client.Do(req)
+		if err != nil {
+			// request fails
+			logp.Warn("Request fails: %s", err)
+			es.connectionPool.MarkDead(conn)
+			return nil, err
+		}
+
+		defer resp.Body.Close()
+		obj, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		var result QueryResult
+		err = json.Unmarshal(obj, &result)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode > 499 {
+			// request fails
+			es.connectionPool.MarkDead(conn)
+			return &result, fmt.Errorf("ES returned an error: %s", resp.Status)
+		}
+		// request with success
+		es.connectionPool.MarkLive(conn)
+
+		return &result, err
 	}
 
-	req, err := http.NewRequest("POST", url, &buf)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Accept", "application/json")
-	if conn.Username != "" || conn.Password != "" {
-		req.SetBasicAuth(conn.Username, conn.Password)
-	}
-
-	resp, err := es.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-	obj, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	var result QueryResult
-	err = json.Unmarshal(obj, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode > 299 {
-		return &result, fmt.Errorf("ES returned an error: %s", resp.Status)
-	}
-	return &result, err
+	return nil, fmt.Errorf("Request fails to be send after %d retries", es.MaxRetries)
 }

--- a/outputs/elasticsearch/bulkapi_mock_test.go
+++ b/outputs/elasticsearch/bulkapi_mock_test.go
@@ -1,0 +1,187 @@
+package elasticsearch
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/elastic/libbeat/logp"
+)
+
+func TestOneHostSuccessResp_Bulk(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
+	}
+
+	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
+	expected_resp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "type1", Id: "1", Version: 1, Created: true})
+
+	ops := []map[string]interface{}{
+		map[string]interface{}{
+			"index": map[string]interface{}{
+				"_index": index,
+				"_type":  "type1",
+				"_id":    "1",
+			},
+		},
+		map[string]interface{}{
+			"field1": "value1",
+		},
+	}
+
+	body := make(chan interface{}, 10)
+	for _, op := range ops {
+		body <- op
+	}
+	close(body)
+
+	server := ElasticsearchMock(200, expected_resp)
+
+	es := NewElasticsearch([]string{server.URL}, "", "")
+
+	params := map[string]string{
+		"refresh": "true",
+	}
+	resp, err := es.Bulk(index, "type1", params, body)
+	if err != nil {
+		t.Errorf("Bulk() returns error: %s", err)
+	}
+	if !resp.Created {
+		t.Errorf("Bulk() fails: %s", resp)
+	}
+}
+
+func TestOneHost500Resp_Bulk(t *testing.T) {
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
+	}
+
+	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
+
+	ops := []map[string]interface{}{
+		map[string]interface{}{
+			"index": map[string]interface{}{
+				"_index": index,
+				"_type":  "type1",
+				"_id":    "1",
+			},
+		},
+		map[string]interface{}{
+			"field1": "value1",
+		},
+	}
+
+	body := make(chan interface{}, 10)
+	for _, op := range ops {
+		body <- op
+	}
+	close(body)
+
+	server := ElasticsearchMock(http.StatusInternalServerError, []byte("Something wrong happened"))
+
+	es := NewElasticsearch([]string{server.URL}, "", "")
+
+	params := map[string]string{
+		"refresh": "true",
+	}
+	_, err := es.Bulk(index, "type1", params, body)
+	if err == nil {
+		t.Errorf("Bulk() should return error.")
+	}
+
+	if !strings.Contains(err.Error(), "500 Internal Server Error") {
+		t.Errorf("Should return <500 Internal Server Error> instead of %v", err)
+	}
+}
+
+func TestOneHost503Resp_Bulk(t *testing.T) {
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
+	}
+
+	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
+
+	ops := []map[string]interface{}{
+		map[string]interface{}{
+			"index": map[string]interface{}{
+				"_index": index,
+				"_type":  "type1",
+				"_id":    "1",
+			},
+		},
+		map[string]interface{}{
+			"field1": "value1",
+		},
+	}
+
+	body := make(chan interface{}, 10)
+	for _, op := range ops {
+		body <- op
+	}
+	close(body)
+
+	server := ElasticsearchMock(503, []byte("Something wrong happened"))
+
+	es := NewElasticsearch([]string{server.URL}, "", "")
+
+	params := map[string]string{
+		"refresh": "true",
+	}
+	_, err := es.Bulk(index, "type1", params, body)
+	if err == nil {
+		t.Errorf("Bulk() should return error.")
+	}
+
+	if !strings.Contains(err.Error(), "retries. Errors") {
+		t.Errorf("Should return <Request fails after 3 retries. Errors: > instead of %v", err)
+	}
+}
+
+func TestMultipleHost_Bulk(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
+	}
+
+	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
+	expected_resp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "type1", Id: "1", Version: 1, Created: true})
+
+	ops := []map[string]interface{}{
+		map[string]interface{}{
+			"index": map[string]interface{}{
+				"_index": index,
+				"_type":  "type1",
+				"_id":    "1",
+			},
+		},
+		map[string]interface{}{
+			"field1": "value1",
+		},
+	}
+
+	body := make(chan interface{}, 10)
+	for _, op := range ops {
+		body <- op
+	}
+	close(body)
+
+	server1 := ElasticsearchMock(503, []byte("Somehting went wrong"))
+	server2 := ElasticsearchMock(200, expected_resp)
+
+	es := NewElasticsearch([]string{server1.URL, server2.URL}, "", "")
+
+	params := map[string]string{
+		"refresh": "true",
+	}
+	resp, err := es.Bulk(index, "type1", params, body)
+	if err != nil {
+		t.Errorf("Bulk() returns error: %s", err)
+	}
+	if !resp.Created {
+		t.Errorf("Bulk() fails: %s", resp)
+	}
+}

--- a/outputs/elasticsearch/connection_pool.go
+++ b/outputs/elasticsearch/connection_pool.go
@@ -1,0 +1,106 @@
+package elasticsearch
+
+import (
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/elastic/libbeat/logp"
+)
+
+type Connection struct {
+	Url      string
+	Username string
+	Password string
+
+	dead       bool
+	dead_count int
+	timer      *time.Timer
+	timeout    time.Duration
+}
+
+const (
+	default_dead_timeout = 60 //seconds
+)
+
+type ConnectionPool struct {
+	Connections []Connection
+	Active      []Connection
+	rr          int //round robin
+}
+
+func (pool *ConnectionPool) SetConnections(urls []string, username string, password string) error {
+
+	var connections []Connection
+
+	for _, url := range urls {
+		conn := Connection{
+			Url:      url,
+			Username: username,
+			Password: password,
+		}
+		// set default settings
+		conn.dead_count = 0
+		connections = append(connections, conn)
+	}
+	pool.Connections = connections
+	pool.Active = connections
+	pool.rr = -1
+	return nil
+}
+
+func (pool *ConnectionPool) SelectRoundRobin() *Connection {
+
+	for count := 0; count < len(pool.Connections); count++ {
+
+		pool.rr += 1
+		pool.rr = pool.rr % len(pool.Connections)
+		conn := pool.Connections[pool.rr]
+		if conn.dead == false {
+			return &conn
+		}
+	}
+
+	// no connection is alive, return a random connection
+	pool.rr = rand.Intn(len(pool.Connections))
+	return &pool.Connections[pool.rr]
+}
+
+func (pool *ConnectionPool) GetConnection() *Connection {
+
+	if len(pool.Connections) > 1 {
+		return pool.SelectRoundRobin()
+	}
+	// only one connection, no need to select one connection
+	return &pool.Connections[0]
+}
+
+// If a connection fails, it will be marked as dead and put on timeout.
+// timeout = default_timeout * 2 ** (fail_count - 1)
+// When the timeout is over, the connection will be resurrected and
+// returned to the live pool
+func (pool *ConnectionPool) MarkDead(conn *Connection) error {
+
+	logp.Debug("elasticsearch", "Mark dead %s", conn.Url)
+	conn.dead = true
+	conn.dead_count = conn.dead_count + 1
+	conn.timeout = time.Duration(default_dead_timeout * math.Pow(2, float64(conn.dead_count)-1))
+	conn.timer = time.AfterFunc(conn.timeout*time.Second, func() {
+		// timeout expires
+		conn.dead = false
+	})
+
+	return nil
+}
+
+// A connection that has been previously marked as dead and succeeds will be marked
+// as live and the dead_count is set to zero
+func (pool *ConnectionPool) MarkLive(conn *Connection) error {
+	if conn.dead {
+		logp.Debug("elasticsearch", "Mark live %s", conn.Url)
+		conn.dead = false
+		conn.dead_count = 0
+		conn.timer.Stop()
+	}
+	return nil
+}

--- a/outputs/elasticsearch/connection_pool_test.go
+++ b/outputs/elasticsearch/connection_pool_test.go
@@ -1,0 +1,138 @@
+package elasticsearch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elastic/libbeat/logp"
+)
+
+
+func TestRoundRobin(t *testing.T) {
+
+	var pool ConnectionPool
+
+	urls := []string{"localhost:9200", "localhost:9201"}
+
+	err := pool.SetConnections(urls, "test", "secret")
+
+	if err != nil {
+		t.Errorf("Fail to set the connections: %s", err)
+	}
+
+	conn := pool.GetConnection()
+
+	if conn.Url != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.Url)
+	}
+
+	conn = pool.GetConnection()
+	if conn.Url != "localhost:9201" {
+		t.Errorf("Wrong connection returned: %s", conn.Url)
+	}
+}
+
+func TestMarkDead(t *testing.T) {
+
+	var pool ConnectionPool
+
+	urls := []string{"localhost:9200", "localhost:9201"}
+
+	err := pool.SetConnections(urls, "test", "secret")
+
+	if err != nil {
+		t.Errorf("Fail to set the connections: %s", err)
+	}
+
+	conn := pool.GetConnection()
+
+	if conn.Url != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.Url)
+	}
+	pool.MarkDead(conn)
+
+	conn = pool.GetConnection()
+	if conn.Url != "localhost:9201" {
+		t.Errorf("Wrong connection returned: %s", conn.Url)
+	}
+
+	conn = pool.GetConnection()
+	if conn.Url != "localhost:9201" {
+		t.Errorf("Wrong connection returned: %s", conn.Url)
+	}
+	pool.MarkDead(conn)
+
+	conn = pool.GetConnection()
+	if conn != nil {
+		t.Errorf("No connection returned %s")
+	}
+
+}
+
+func TestDeadTimeout(t *testing.T) {
+
+	if testing.Verbose() {
+		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
+	}
+
+
+	var pool ConnectionPool
+
+	urls := []string{"localhost:9200", "localhost:9201"}
+
+	err := pool.SetConnections(urls, "test", "secret")
+	if err != nil {
+		t.Errorf("Fail to set the connections: %s", err)
+	}
+	pool.SetDeadTimeout(10)
+
+	conn := pool.GetConnection()
+
+	if conn.Url != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.Url)
+	}
+	pool.MarkDead(conn)
+	time.Sleep(10 * time.Second)
+
+	conn = pool.GetConnection()
+	if conn.Url != "localhost:9201" {
+		t.Errorf("Wrong connection returned: %s", conn.Url)
+	}
+
+	conn = pool.GetConnection()
+	if conn.Url != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.Url)
+	}
+}
+
+func TestMarkLive(t *testing.T) {
+
+	var pool ConnectionPool
+
+	urls := []string{"localhost:9200", "localhost:9201"}
+
+	err := pool.SetConnections(urls, "test", "secret")
+
+	if err != nil {
+		t.Errorf("Fail to set the connections: %s", err)
+	}
+
+	conn := pool.GetConnection()
+	if conn.Url != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.Url)
+	}
+	pool.MarkDead(conn)
+	pool.MarkLive(conn)
+
+	conn = pool.GetConnection()
+	if conn.Url != "localhost:9201" {
+		t.Errorf("Wrong connection returned: %s", conn.Url)
+	}
+	conn = pool.GetConnection()
+	if conn.Url != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.Url)
+	}
+
+}
+
+

--- a/outputs/elasticsearch/connection_pool_test.go
+++ b/outputs/elasticsearch/connection_pool_test.go
@@ -63,7 +63,7 @@ func TestMarkDead(t *testing.T) {
 
 	conn = pool.GetConnection()
 	if conn.Url != "localhost:9201" && conn.Url != "localhost:9200" {
-		t.Errorf("No connection returned: %s", conn)
+		t.Errorf("No expected connection returned")
 	}
 
 }

--- a/outputs/elasticsearch/connection_pool_test.go
+++ b/outputs/elasticsearch/connection_pool_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/elastic/libbeat/logp"
 )
 
-
 func TestRoundRobin(t *testing.T) {
 
 	var pool ConnectionPool
@@ -63,8 +62,8 @@ func TestMarkDead(t *testing.T) {
 	pool.MarkDead(conn)
 
 	conn = pool.GetConnection()
-	if conn != nil {
-		t.Errorf("No connection returned %s")
+	if conn.Url != "localhost:9201" && conn.Url != "localhost:9200" {
+		t.Errorf("No connection returned: %s", conn)
 	}
 
 }
@@ -74,7 +73,6 @@ func TestDeadTimeout(t *testing.T) {
 	if testing.Verbose() {
 		logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"elasticsearch"})
 	}
-
 
 	var pool ConnectionPool
 
@@ -134,5 +132,3 @@ func TestMarkLive(t *testing.T) {
 	}
 
 }
-
-

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -27,6 +27,7 @@ type MothershipConfig struct {
 	DataType           string
 	Flush_interval     *int
 	Bulk_size          *int
+	Max_retries		   *int
 }
 
 // Functions to be exported by a output plugin

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -27,7 +27,7 @@ type MothershipConfig struct {
 	DataType           string
 	Flush_interval     *int
 	Bulk_size          *int
-	Max_retries		   *int
+	Max_retries        *int
 }
 
 // Functions to be exported by a output plugin

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -11,6 +11,7 @@ type MothershipConfig struct {
 	Save_topology      bool
 	Host               string
 	Port               int
+	Hosts              []string
 	Protocol           string
 	Username           string
 	Password           string


### PR DESCRIPTION
A list of Elasticsearch nodes can be configured by using the `hosts` options. The `host` and `port` options become obsolete, but for backward compatibility, if they are set, a single Elasticsearch node will be used.

  elasticsearch:
    enabled: true
    #host: localhost
    #port: 9200
    hosts: ["localhost:9200", "localhost:9201"]

In case a list of Elasticsearch nodes is configured, for each Elasticsearch operation, a node is selected using the Round Robin technique. If the operation fails, the connection is marked as dead and put on timeout. The timeout is calculated based on the number of failures:

    default_timeout * 2 ** (fail_count - 1) 
  
As long as the connection is marked as dead, the connection is not used. When the timeout is over, the connection is marked as alive. If a connection that is previously marked as dead, succeeds, it is marked as alive and the fail_count is set to zero.

If all the connections are marked as dead, a random connection will be used. 

When an operation fails, it is retried up to max_retries (configurable, by default is 3).

 The algorithm is modeled after the Elasticsearch python client: http://elasticsearch-py.readthedocs.org/en/master/connection.html
