### PR TITLE
Don't exit when Elasticsearch is not available at startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: go
+
+go:
+    - 1.4
+
+sudo: false
+
+services:
+    - redis-server
+    - elasticsearch
+
+addonsbefore_install:
+    - ln -s $TRAVIS_BUILD_DIR $HOME/gopath/src/libbeat
+
+install:
+    - make
+
+script: make testlong
+
+notifications:
+    email:
+        - tudor@elastic.co
+        - monica@elastic.co

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -20,6 +20,8 @@ type ElasticsearchOutput struct {
 
 	TopologyMap  map[string]string
 	sendingQueue chan EventMsg
+
+	ttlEnabled bool
 }
 
 type PublishedTopology struct {
@@ -87,7 +89,17 @@ func (out *ElasticsearchOutput) Init(config outputs.MothershipConfig, topology_e
 	err := out.EnableTTL()
 	if err != nil {
 		logp.Err("Fail to set _ttl mapping: %s", err)
-		return err
+		// keep trying in the background
+		go func() {
+			for {
+				err := out.EnableTTL()
+				if err == nil {
+					break
+				}
+				logp.Err("Fail to set _ttl mapping: %s", err)
+				time.Sleep(5 * time.Second)
+			}
+		}()
 	}
 
 	out.sendingQueue = make(chan EventMsg, 1000)
@@ -112,6 +124,9 @@ func (out *ElasticsearchOutput) EnableTTL() error {
 	if err != nil {
 		return err
 	}
+
+	out.ttlEnabled = true
+
 	return nil
 }
 
@@ -181,6 +196,11 @@ func (out *ElasticsearchOutput) SendMessagesGoroutine() {
 
 // Each shipper publishes a list of IPs together with its name to Elasticsearch
 func (out *ElasticsearchOutput) PublishIPs(name string, localAddrs []string) error {
+	if !out.ttlEnabled {
+		logp.Debug("output_elasticsearch", "Not publishing IPs because TTL was not yet confirmed to be enabled")
+		return nil
+	}
+
 	logp.Debug("output_elasticsearch", "Publish IPs %s with expiration time %d", localAddrs, out.TopologyExpire)
 	params := map[string]string{
 		"ttl":     fmt.Sprintf("%dms", out.TopologyExpire),

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -86,20 +86,22 @@ func (out *ElasticsearchOutput) Init(config outputs.MothershipConfig, topology_e
 		logp.Info("[ElasticsearchOutput] Insert events one by one. This might affect the performance of the shipper.")
 	}
 
-	err := out.EnableTTL()
-	if err != nil {
-		logp.Err("Fail to set _ttl mapping: %s", err)
-		// keep trying in the background
-		go func() {
-			for {
-				err := out.EnableTTL()
-				if err == nil {
-					break
+	if config.Save_topology {
+		err := out.EnableTTL()
+		if err != nil {
+			logp.Err("Fail to set _ttl mapping: %s", err)
+			// keep trying in the background
+			go func() {
+				for {
+					err := out.EnableTTL()
+					if err == nil {
+						break
+					}
+					logp.Err("Fail to set _ttl mapping: %s", err)
+					time.Sleep(5 * time.Second)
 				}
-				logp.Err("Fail to set _ttl mapping: %s", err)
-				time.Sleep(5 * time.Second)
-			}
-		}()
+			}()
+		}
 	}
 
 	out.sendingQueue = make(chan EventMsg, 1000)


### PR DESCRIPTION
The topology saving code used to try setting the TTL mapping on the `.packetbeat-topology` index and return an error when failing. This was somewhat convenient because it detected configuration errors (Elasticsearch not reachable) in the default configuration, but causes problems at boot time if Packetbeat starts before Elasticsearch.

The pull request makes the code keep trying every 5 seconds in the background to create the index and set the mapping. Until the mapping is confirmed to have been configure, no index requests are let through that index.

The first try is done in foreground, to make it easy for the unit tests.

This PR also adds a .travis.yml and fixes another related issue: if `save_topology` is set to false, don't try to create the `.packetbeat-topology` index.

Closes https://github.com/elastic/packetbeat/issues/187.