### PR TITLE
RFC: eliminate snake case and simplify unambiguous names

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -8,21 +8,21 @@ import (
 
 // Byte order utilities
 
-func Bytes_Ntohs(b []byte) uint16 {
+func Ntohs(b []byte) uint16 {
 	return uint16(b[0])<<8 | uint16(b[1])
 }
 
-func Bytes_Ntohl(b []byte) uint32 {
+func Ntohl(b []byte) uint32 {
 	return uint32(b[0])<<24 | uint32(b[1])<<16 |
 		uint32(b[2])<<8 | uint32(b[3])
 }
 
-func Bytes_Htohl(b []byte) uint32 {
+func Htonl(b []byte) uint32 {
 	return uint32(b[3])<<24 | uint32(b[2])<<16 |
 		uint32(b[1])<<8 | uint32(b[0])
 }
 
-func Bytes_Ntohll(b []byte) uint64 {
+func Ntohll(b []byte) uint64 {
 	return uint64(b[0])<<56 | uint64(b[1])<<48 |
 		uint64(b[2])<<40 | uint64(b[3])<<32 |
 		uint64(b[4])<<24 | uint64(b[5])<<16 |
@@ -30,7 +30,7 @@ func Bytes_Ntohll(b []byte) uint64 {
 }
 
 // Ipv4_Ntoa transforms an IP4 address in it's dotted notation
-func Ipv4_Ntoa(ip uint32) string {
+func Ipv4Ntoa(ip uint32) string {
 	return fmt.Sprintf("%d.%d.%d.%d",
 		byte(ip>>24), byte(ip>>16),
 		byte(ip>>8), byte(ip))

--- a/common/bytes_test.go
+++ b/common/bytes_test.go
@@ -33,7 +33,7 @@ func TestBytes_Ntohs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.Output, Bytes_Ntohs(test.Input))
+		assert.Equal(t, test.Output, Ntohs(test.Input))
 	}
 }
 
@@ -67,7 +67,7 @@ func TestBytes_Ntohl(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.Output, Bytes_Ntohl(test.Input))
+		assert.Equal(t, test.Output, Ntohl(test.Input))
 	}
 }
 
@@ -101,7 +101,7 @@ func TestBytes_Htohl(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.Output, Bytes_Htohl(test.Input))
+		assert.Equal(t, test.Output, Htonl(test.Input))
 	}
 }
 
@@ -151,7 +151,7 @@ func TestBytes_Ntohll(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.Output, Bytes_Ntohll(test.Input))
+		assert.Equal(t, test.Output, Ntohll(test.Input))
 	}
 }
 
@@ -177,7 +177,7 @@ func TestIpv4_Ntoa(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.Output, Ipv4_Ntoa(test.Input))
+		assert.Equal(t, test.Output, Ipv4Ntoa(test.Input))
 	}
 }
 

--- a/common/geolite.go
+++ b/common/geolite.go
@@ -9,27 +9,29 @@ import (
 	"github.com/nranchev/go-libGeoIP"
 )
 
-type Geoip struct {
-	Paths *[]string
+type GeoIp struct {
+	Paths []string
 }
 
-func LoadGeoIPData(config Geoip) *libgeo.GeoIP {
+// TODO(shutej): Don't hard-code unix paths.  This could be a platform-specific
+// build variable or a library flag with a default location, what makes sense?
+var geoipPaths = []string{
+	"/usr/share/GeoIP/GeoIP.dat",
+	"/usr/local/var/GeoIP/GeoIP.dat",
+}
 
-	geoip_paths := []string{
-		"/usr/share/GeoIP/GeoIP.dat",
-		"/usr/local/var/GeoIP/GeoIP.dat",
-	}
+func LoadGeoIPData(config GeoIp) *libgeo.GeoIP {
 	if config.Paths != nil {
-		geoip_paths = *config.Paths
+		geoipPaths = config.Paths
 	}
-	if len(geoip_paths) == 0 {
+	if len(geoipPaths) == 0 {
 		// disabled
 		return nil
 	}
 
 	// look for the first existing path
-	var geoip_path string
-	for _, path := range geoip_paths {
+	var geoipPath string
+	for _, path := range geoipPaths {
 		fi, err := os.Lstat(path)
 		if err != nil {
 			continue
@@ -37,27 +39,27 @@ func LoadGeoIPData(config Geoip) *libgeo.GeoIP {
 
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
 			// follow symlink
-			geoip_path, err = filepath.EvalSymlinks(path)
+			geoipPath, err = filepath.EvalSymlinks(path)
 			if err != nil {
 				logp.Warn("Could not load GeoIP data: %s", err.Error())
 				return nil
 			}
 		} else {
-			geoip_path = path
+			geoipPath = path
 		}
 		break
 	}
 
-	if len(geoip_path) == 0 {
+	if len(geoipPath) == 0 {
 		logp.Warn("Couldn't load GeoIP database")
 		return nil
 	}
 
-	geoLite, err := libgeo.Load(geoip_path)
+	geoLite, err := libgeo.Load(geoipPath)
 	if err != nil {
 		logp.Warn("Could not load GeoIP data: %s", err.Error())
 	}
 
-	logp.Info("Loaded GeoIP data from: %s", geoip_path)
+	logp.Info("Loaded GeoIP data from: %s", geoipPath)
 	return geoLite
 }

--- a/common/tuples.go
+++ b/common/tuples.go
@@ -16,47 +16,47 @@ const MaxIpPortTupleRawSize = 16 + 16 + 2 + 2
 type HashableIpPortTuple [MaxIpPortTupleRawSize]byte
 
 type IpPortTuple struct {
-	Ip_length          int
-	Src_ip, Dst_ip     net.IP
-	Src_port, Dst_port uint16
+	IpLength         int
+	SrcIp, DstIp     net.IP
+	SrcPort, DstPort uint16
 
-	raw    HashableIpPortTuple // Src_ip:Src_port:Dst_ip:Dst_port
-	revRaw HashableIpPortTuple // Dst_ip:Dst_port:Src_ip:Src_port
+	raw    HashableIpPortTuple // SrcIp:SrcPort:DstIp:DstPort
+	revRaw HashableIpPortTuple // DstIp:DstPort:SrcIp:SrcPort
 }
 
-func NewIpPortTuple(ip_length int, src_ip net.IP, src_port uint16,
-	dst_ip net.IP, dst_port uint16) IpPortTuple {
+func NewIpPortTuple(ipLength int, srcIp net.IP, srcPort uint16,
+	dstIp net.IP, dstPort uint16) IpPortTuple {
 
 	tuple := IpPortTuple{
-		Ip_length: ip_length,
-		Src_ip:    src_ip,
-		Dst_ip:    dst_ip,
-		Src_port:  src_port,
-		Dst_port:  dst_port,
+		IpLength: ipLength,
+		SrcIp:    srcIp,
+		DstIp:    dstIp,
+		SrcPort:  srcPort,
+		DstPort:  dstPort,
 	}
-	tuple.ComputeHashebles()
+	tuple.ComputeHashables()
 
 	return tuple
 }
 
-func (t *IpPortTuple) ComputeHashebles() {
-	copy(t.raw[0:16], t.Src_ip)
-	copy(t.raw[16:18], []byte{byte(t.Src_port >> 8), byte(t.Src_port)})
-	copy(t.raw[18:34], t.Dst_ip)
-	copy(t.raw[34:36], []byte{byte(t.Dst_port >> 8), byte(t.Dst_port)})
+func (t *IpPortTuple) ComputeHashables() {
+	copy(t.raw[0:16], t.SrcIp)
+	copy(t.raw[16:18], []byte{byte(t.SrcPort >> 8), byte(t.SrcPort)})
+	copy(t.raw[18:34], t.DstIp)
+	copy(t.raw[34:36], []byte{byte(t.DstPort >> 8), byte(t.DstPort)})
 
-	copy(t.revRaw[0:16], t.Dst_ip)
-	copy(t.revRaw[16:18], []byte{byte(t.Dst_port >> 8), byte(t.Dst_port)})
-	copy(t.revRaw[18:34], t.Src_ip)
-	copy(t.revRaw[34:36], []byte{byte(t.Src_port >> 8), byte(t.Src_port)})
+	copy(t.revRaw[0:16], t.DstIp)
+	copy(t.revRaw[16:18], []byte{byte(t.DstPort >> 8), byte(t.DstPort)})
+	copy(t.revRaw[18:34], t.SrcIp)
+	copy(t.revRaw[34:36], []byte{byte(t.SrcPort >> 8), byte(t.SrcPort)})
 }
 
 func (t *IpPortTuple) String() string {
 	return fmt.Sprintf("IpPortTuple src[%s:%d] dst[%s:%d]",
-		t.Src_ip.String(),
-		t.Src_port,
-		t.Dst_ip.String(),
-		t.Dst_port)
+		t.SrcIp.String(),
+		t.SrcPort,
+		t.DstIp.String(),
+		t.DstPort)
 }
 
 // Hashable returns a hashable value that uniquely identifies
@@ -76,51 +76,51 @@ const MaxTcpTupleRawSize = 16 + 16 + 2 + 2 + 4
 type HashableTcpTuple [MaxTcpTupleRawSize]byte
 
 type TcpTuple struct {
-	Ip_length          int
-	Src_ip, Dst_ip     net.IP
-	Src_port, Dst_port uint16
-	Stream_id          uint32
+	IpLength         int
+	SrcIp, DstIp     net.IP
+	SrcPort, DstPort uint16
+	StreamId         uint32
 
-	raw HashableTcpTuple // Src_ip:Src_port:Dst_ip:Dst_port:stream_id
+	raw HashableTcpTuple // SrcIp:SrcPort:DstIp:DstPort:stream_id
 }
 
 func TcpTupleFromIpPort(t *IpPortTuple, tcp_id uint32) TcpTuple {
 	tuple := TcpTuple{
-		Ip_length: t.Ip_length,
-		Src_ip:    t.Src_ip,
-		Dst_ip:    t.Dst_ip,
-		Src_port:  t.Src_port,
-		Dst_port:  t.Dst_port,
-		Stream_id: tcp_id,
+		IpLength: t.IpLength,
+		SrcIp:    t.SrcIp,
+		DstIp:    t.DstIp,
+		SrcPort:  t.SrcPort,
+		DstPort:  t.DstPort,
+		StreamId: tcp_id,
 	}
-	tuple.ComputeHashebles()
+	tuple.ComputeHashables()
 
 	return tuple
 }
 
-func (t *TcpTuple) ComputeHashebles() {
-	copy(t.raw[0:16], t.Src_ip)
-	copy(t.raw[16:18], []byte{byte(t.Src_port >> 8), byte(t.Src_port)})
-	copy(t.raw[18:34], t.Dst_ip)
-	copy(t.raw[34:36], []byte{byte(t.Dst_port >> 8), byte(t.Dst_port)})
-	copy(t.raw[36:40], []byte{byte(t.Stream_id >> 24), byte(t.Stream_id >> 16),
-		byte(t.Stream_id >> 8), byte(t.Stream_id)})
+func (t *TcpTuple) ComputeHashables() {
+	copy(t.raw[0:16], t.SrcIp)
+	copy(t.raw[16:18], []byte{byte(t.SrcPort >> 8), byte(t.SrcPort)})
+	copy(t.raw[18:34], t.DstIp)
+	copy(t.raw[34:36], []byte{byte(t.DstPort >> 8), byte(t.DstPort)})
+	copy(t.raw[36:40], []byte{byte(t.StreamId >> 24), byte(t.StreamId >> 16),
+		byte(t.StreamId >> 8), byte(t.StreamId)})
 }
 
 func (t TcpTuple) String() string {
 	return fmt.Sprintf("TcpTuple src[%s:%d] dst[%s:%d] stream_id[%d]",
-		t.Src_ip.String(),
-		t.Src_port,
-		t.Dst_ip.String(),
-		t.Dst_port,
-		t.Stream_id)
+		t.SrcIp.String(),
+		t.SrcPort,
+		t.DstIp.String(),
+		t.DstPort,
+		t.StreamId)
 }
 
 // Returns a pointer to the equivalent IpPortTuple.
 func (t TcpTuple) IpPort() *IpPortTuple {
-	ipport := NewIpPortTuple(t.Ip_length, t.Src_ip, t.Src_port,
-		t.Dst_ip, t.Dst_port)
-	return &ipport
+	ipPort := NewIpPortTuple(t.IpLength, t.SrcIp, t.SrcPort,
+		t.DstIp, t.DstPort)
+	return &ipPort
 }
 
 // Hashable() returns a hashable value that uniquely identifies

--- a/logp/file_rotator.go
+++ b/logp/file_rotator.go
@@ -91,16 +91,16 @@ func (rotator *FileRotator) shouldRotate() bool {
 	return false
 }
 
-func (rotator *FileRotator) FilePath(file_no int) string {
-	if file_no == 0 {
+func (rotator *FileRotator) FilePath(fileNo int) string {
+	if fileNo == 0 {
 		return filepath.Join(rotator.Path, rotator.Name)
 	}
-	filename := strings.Join([]string{rotator.Name, strconv.Itoa(file_no)}, ".")
+	filename := strings.Join([]string{rotator.Name, strconv.Itoa(fileNo)}, ".")
 	return filepath.Join(rotator.Path, filename)
 }
 
-func (rotator *FileRotator) FileExists(file_no int) bool {
-	file_path := rotator.FilePath(file_no)
+func (rotator *FileRotator) FileExists(fileNo int) bool {
+	file_path := rotator.FilePath(fileNo)
 	_, err := os.Stat(file_path)
 	if os.IsNotExist(err) {
 		return false
@@ -117,9 +117,9 @@ func (rotator *FileRotator) Rotate() error {
 	}
 
 	// delete any extra files, normally we shouldn't have any
-	for file_no := *rotator.KeepFiles; file_no < RotatorMaxFiles; file_no++ {
-		if rotator.FileExists(file_no) {
-			perr := os.Remove(rotator.FilePath(file_no))
+	for fileNo := *rotator.KeepFiles; fileNo < RotatorMaxFiles; fileNo++ {
+		if rotator.FileExists(fileNo) {
+			perr := os.Remove(rotator.FilePath(fileNo))
 			if perr != nil {
 				return perr
 			}
@@ -127,19 +127,19 @@ func (rotator *FileRotator) Rotate() error {
 	}
 
 	// shift all files from last to first
-	for file_no := *rotator.KeepFiles - 1; file_no >= 0; file_no-- {
-		if !rotator.FileExists(file_no) {
+	for fileNo := *rotator.KeepFiles - 1; fileNo >= 0; fileNo-- {
+		if !rotator.FileExists(fileNo) {
 			// file doesn't exist, don't rotate
 			continue
 		}
-		file_path := rotator.FilePath(file_no)
+		file_path := rotator.FilePath(fileNo)
 
-		if rotator.FileExists(file_no + 1) {
+		if rotator.FileExists(fileNo + 1) {
 			// next file exists, something is strange
-			return fmt.Errorf("File %s exists, when rotating would overwrite it", rotator.FilePath(file_no+1))
+			return fmt.Errorf("File %s exists, when rotating would overwrite it", rotator.FilePath(fileNo+1))
 		}
 
-		err := os.Rename(file_path, rotator.FilePath(file_no+1))
+		err := os.Rename(file_path, rotator.FilePath(fileNo+1))
 		if err != nil {
 			return err
 		}

--- a/logp/logp.go
+++ b/logp/logp.go
@@ -17,8 +17,8 @@ var debugSelectorsStr *string
 type Logging struct {
 	Selectors []string
 	Files     *FileRotator
-	To_syslog *bool
-	To_files  *bool
+	ToSyslog  *bool
+	ToFiles   *bool
 }
 
 // Init combines the configuration from config with the command line
@@ -49,13 +49,13 @@ func Init(name string, config *Logging) error {
 	}
 
 	var toSyslog, toFiles bool
-	if config.To_syslog != nil {
-		toSyslog = *config.To_syslog
+	if config.ToSyslog != nil {
+		toSyslog = *config.ToSyslog
 	} else {
 		toSyslog = defaultToSyslog
 	}
-	if config.To_files != nil {
-		toFiles = *config.To_files
+	if config.ToFiles != nil {
+		toFiles = *config.ToFiles
 	} else {
 		toFiles = defaultToFiles
 	}

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -30,7 +30,7 @@ type PublishedTopology struct {
 }
 
 // Initialize Elasticsearch as output
-func (out *ElasticsearchOutput) Init(config outputs.MothershipConfig, topology_expire int) error {
+func (out *ElasticsearchOutput) Init(config outputs.Config, topology_expire int) error {
 
 	if len(config.Protocol) == 0 {
 		config.Protocol = "http"
@@ -65,16 +65,16 @@ func (out *ElasticsearchOutput) Init(config outputs.MothershipConfig, topology_e
 	}
 
 	out.FlushInterval = 1000 * time.Millisecond
-	if config.Flush_interval != nil {
-		out.FlushInterval = time.Duration(*config.Flush_interval) * time.Millisecond
+	if config.FlushInterval != nil {
+		out.FlushInterval = time.Duration(*config.FlushInterval) * time.Millisecond
 	}
 	out.BulkMaxSize = 10000
-	if config.Bulk_size != nil {
-		out.BulkMaxSize = *config.Bulk_size
+	if config.BulkSize != nil {
+		out.BulkMaxSize = *config.BulkSize
 	}
 
-	if config.Max_retries != nil {
-		out.Conn.SetMaxRetries(*config.Max_retries)
+	if config.MaxRetries != nil {
+		out.Conn.SetMaxRetries(*config.MaxRetries)
 	}
 
 	logp.Info("[ElasticsearchOutput] Using Elasticsearch %s", urls)
@@ -86,7 +86,7 @@ func (out *ElasticsearchOutput) Init(config outputs.MothershipConfig, topology_e
 		logp.Info("[ElasticsearchOutput] Insert events one by one. This might affect the performance of the shipper.")
 	}
 
-	if config.Save_topology {
+	if config.SaveTopology {
 		err := out.EnableTTL()
 		if err != nil {
 			logp.Err("Fail to set _ttl mapping: %s", err)

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -36,18 +36,18 @@ func createElasticsearchConnection(flush_interval int, bulk_size int) Elasticsea
 	}
 
 	var elasticsearchOutput ElasticsearchOutput
-	elasticsearchOutput.Init(outputs.MothershipConfig{
-		Enabled:        true,
-		Save_topology:  true,
-		Host:           elasticsearchAddr,
-		Port:           es_port,
-		Username:       "",
-		Password:       "",
-		Path:           "",
-		Index:          index,
-		Protocol:       "",
-		Flush_interval: &flush_interval,
-		Bulk_size:      &bulk_size,
+	elasticsearchOutput.Init(outputs.Config{
+		Enabled:       true,
+		SaveTopology:  true,
+		Host:          elasticsearchAddr,
+		Port:          es_port,
+		Username:      "",
+		Password:      "",
+		Path:          "",
+		Index:         index,
+		Protocol:      "",
+		FlushInterval: &flush_interval,
+		BulkSize:      &bulk_size,
 	}, 10)
 
 	return elasticsearchOutput

--- a/outputs/fileout/file.go
+++ b/outputs/fileout/file.go
@@ -13,20 +13,20 @@ type FileOutput struct {
 	rotator logp.FileRotator
 }
 
-func (out *FileOutput) Init(config outputs.MothershipConfig, topology_expire int) error {
+func (out *FileOutput) Init(config outputs.Config, topologyExpire int) error {
 	out.rotator.Path = config.Path
 	out.rotator.Name = config.Filename
 	if out.rotator.Name == "" {
 		out.rotator.Name = "packetbeat"
 	}
 
-	rotateeverybytes := uint64(config.Rotate_every_kb) * 1024
+	rotateeverybytes := uint64(config.RotateEveryKb) * 1024
 	if rotateeverybytes == 0 {
 		rotateeverybytes = 10 * 1024 * 1024
 	}
 	out.rotator.RotateEveryBytes = &rotateeverybytes
 
-	keepfiles := config.Number_of_files
+	keepfiles := config.NumberOfFiles
 	if keepfiles == 0 {
 		keepfiles = 7
 	}

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -6,34 +6,34 @@ import (
 	"github.com/elastic/libbeat/common"
 )
 
-type MothershipConfig struct {
-	Enabled            bool
-	Save_topology      bool
-	Host               string
-	Port               int
-	Hosts              []string
-	Protocol           string
-	Username           string
-	Password           string
-	Index              string
-	Path               string
-	Db                 int
-	Db_topology        int
-	Timeout            int
-	Reconnect_interval int
-	Filename           string
-	Rotate_every_kb    int
-	Number_of_files    int
-	DataType           string
-	Flush_interval     *int
-	Bulk_size          *int
-	Max_retries        *int
+type Config struct {
+	Enabled           bool
+	SaveTopology      bool
+	Host              string
+	Port              int
+	Hosts             []string
+	Protocol          string
+	Username          string
+	Password          string
+	Index             string
+	Path              string
+	Db                int
+	DbTopology        int
+	Timeout           int
+	ReconnectInterval int
+	Filename          string
+	RotateEveryKb     int
+	NumberOfFiles     int
+	DataType          string
+	FlushInterval     *int
+	BulkSize          *int
+	MaxRetries        *int
 }
 
 // Functions to be exported by a output plugin
-type OutputInterface interface {
+type Interface interface {
 	// Initialize the output plugin
-	Init(config MothershipConfig, topology_expire int) error
+	Init(config Config, topologyExpire int) error
 
 	// Register the agent name and its IPs to the topology map
 	PublishIPs(name string, localAddrs []string) error

--- a/outputs/redis/redis.go
+++ b/outputs/redis/redis.go
@@ -46,7 +46,7 @@ type RedisQueueMsg struct {
 	msg   string
 }
 
-func (out *RedisOutput) Init(config outputs.MothershipConfig, topology_expire int) error {
+func (out *RedisOutput) Init(config outputs.Config, topology_expire int) error {
 
 	out.Hostname = fmt.Sprintf("%s:%d", config.Host, config.Port)
 
@@ -59,8 +59,8 @@ func (out *RedisOutput) Init(config outputs.MothershipConfig, topology_expire in
 	}
 
 	out.DbTopology = 1
-	if config.Db_topology != 0 {
-		out.DbTopology = config.Db_topology
+	if config.DbTopology != 0 {
+		out.DbTopology = config.DbTopology
 	}
 
 	out.Timeout = 5 * time.Second
@@ -75,18 +75,18 @@ func (out *RedisOutput) Init(config outputs.MothershipConfig, topology_expire in
 	}
 
 	out.FlushInterval = 1000 * time.Millisecond
-	if config.Flush_interval != nil {
-		if *config.Flush_interval < 0 {
+	if config.FlushInterval != nil {
+		if *config.FlushInterval < 0 {
 			out.flush_immediatelly = true
 			logp.Warn("Flushing to REDIS on each push, performance migh be affected")
 		} else {
-			out.FlushInterval = time.Duration(*config.Flush_interval) * time.Millisecond
+			out.FlushInterval = time.Duration(*config.FlushInterval) * time.Millisecond
 		}
 	}
 
 	out.ReconnectInterval = time.Duration(1) * time.Second
-	if config.Reconnect_interval != 0 {
-		out.ReconnectInterval = time.Duration(config.Reconnect_interval) * time.Second
+	if config.ReconnectInterval != 0 {
+		out.ReconnectInterval = time.Duration(config.ReconnectInterval) * time.Second
 	}
 
 	exp_sec := 15


### PR DESCRIPTION
Hi,

I was reading this package and I noticed a few things:

1. There are instances of snake-case in several places.  This is generally not idiomatic in Go.  If camel case is required for reflection mangling, generally people explicitly call it out in struct tags.
2. A few of the identifiers could be simplified, using the fact that Go generally qualifies imports to disambiguate what they are.  For instance, if there's only one interface in a package, you can just call it `Interface`.

As such, I wanted to send this over for comments.  I realize these would be backward-incompatible changes but I could certainly go on and fix packetbeat and other notable consumers (or perhaps write a `go vet` or some such to clean up examples in folks' private repos).

I also notice that in several places the acronyms are capitalized (`IP`) vs. camelcased (`Ip`), but before fixing those wanted to get some comments.

Jeremy