### PR TITLE
Move more common functionality into libbeat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addonsbefore_install:
     - ln -s $TRAVIS_BUILD_DIR $HOME/gopath/src/libbeat
 
 before_script:
-    - sleep 10 
+    - sleep 10
 
 install:
     - make deps

--- a/cfgfile/cfgfile.go
+++ b/cfgfile/cfgfile.go
@@ -1,0 +1,34 @@
+package cfgfile
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Command line flags
+var configfile *string
+var testConfig *bool
+
+func CmdLineFlags(flags *flag.FlagSet) {
+	configfile = flags.String("c", "/etc/packetbeat/packetbeat.yml", "Configuration file")
+	testConfig = flags.Bool("test", false, "Test configuration and exit.")
+}
+
+func Read(out interface{}) error {
+	filecontent, err := ioutil.ReadFile(*configfile)
+	if err != nil {
+		return fmt.Errorf("Fail to read %s: %v. Exiting.", *configfile, err)
+	}
+	if err = yaml.Unmarshal(filecontent, out); err != nil {
+		fmt.Errorf("YAML config parsing failed on %s: %v. Exiting.", *configfile, err)
+	}
+
+	return nil
+}
+
+func IsTestConfig() bool {
+	return *testConfig
+}

--- a/filters/filters_runner.go
+++ b/filters/filters_runner.go
@@ -1,0 +1,141 @@
+package filters
+
+import (
+	"fmt"
+
+	"github.com/elastic/libbeat/common"
+	"github.com/elastic/libbeat/logp"
+)
+
+// Executes the filters
+type FilterRunner struct {
+	FiltersQueue chan common.MapStr
+	results      chan common.MapStr
+
+	// The order in which the plugins are
+	// executed. A filter plugin can be loaded
+	// more than once.
+	order []FilterPlugin
+}
+
+// Goroutine that reads the objects from the FiltersQueue,
+// executes all filters on them and writes the modified objects
+// in the results channel.
+func (runner *FilterRunner) Run() error {
+	for event := range runner.FiltersQueue {
+		for _, plugin := range runner.order {
+			var err error
+			event, err = plugin.Filter(event)
+			if err != nil {
+				logp.Err("Error executing filter %s: %v. Dropping event.", plugin, err)
+				break // drop event in case of errors
+			}
+		}
+
+		runner.results <- event
+	}
+	return nil
+}
+
+// Create a new FilterRunner
+func NewFilterRunner(results chan common.MapStr, order []FilterPlugin) *FilterRunner {
+	runner := new(FilterRunner)
+	runner.results = results
+	runner.order = order
+	runner.FiltersQueue = make(chan common.MapStr, 1000)
+	return runner
+}
+
+// LoadConfiguredFilters interprets the [filters] configuration, loads the configured
+// plugins and returns the order in which they need to be executed.
+func LoadConfiguredFilters(config map[string]interface{}) ([]FilterPlugin, error) {
+	var err error
+	plugins := []FilterPlugin{}
+
+	filters_list, exists := config["filters"]
+	if !exists {
+		return plugins, nil
+	}
+	filters_iface, ok := filters_list.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Expected the filters to be an array of strings")
+	}
+
+	for _, filter_iface := range filters_iface {
+		filter, ok := filter_iface.(string)
+		if !ok {
+			return nil, fmt.Errorf("Expected the filters array to only contain strings")
+		}
+		cfg, exists := config[filter]
+		var plugin_type Filter
+		var plugin_config map[string]interface{}
+		if !exists {
+			// Maybe default configuration by name
+			plugin_type, err = FilterFromName(filter)
+			if err != nil {
+				return nil, fmt.Errorf("No such filter type and no corresponding configuration: %s", filter)
+			}
+		} else {
+			logp.Debug("filters", "%v", cfg)
+			plugin_config, ok := cfg.(map[interface{}]interface{})
+			if !ok {
+				return nil, fmt.Errorf("Invalid configuration for: %s", filter)
+			}
+			type_str, ok := plugin_config["type"].(string)
+			if !ok {
+				return nil, fmt.Errorf("Couldn't get type for filter: %s", filter)
+			}
+			plugin_type, err = FilterFromName(type_str)
+			if err != nil {
+				return nil, fmt.Errorf("No such filter type: %s", type_str)
+			}
+		}
+
+		filter_plugin := Filters.Get(plugin_type)
+		if filter_plugin == nil {
+			return nil, fmt.Errorf("No plugin loaded for %s", plugin_type)
+		}
+		plugin, err := filter_plugin.New(filter, plugin_config)
+		if err != nil {
+			return nil, fmt.Errorf("Initializing filter plugin %s failed: %v",
+				plugin_type, err)
+		}
+		plugins = append(plugins, plugin)
+
+	}
+
+	return plugins, nil
+}
+
+func FiltersRun(config common.MapStr, plugins map[Filter]FilterPlugin,
+	next chan common.MapStr, stopCb func()) (input chan common.MapStr, err error) {
+
+	logp.Debug("filters", "Initializing filters plugins")
+
+	for filter, plugin := range plugins {
+		Filters.Register(filter, plugin)
+	}
+	filters_plugins, err :=
+		LoadConfiguredFilters(config)
+	if err != nil {
+		return nil, fmt.Errorf("Error loading filters plugins: %v", err)
+	}
+	logp.Debug("filters", "Filters plugins order: %v", filters_plugins)
+
+	if len(filters_plugins) > 0 {
+		runner := NewFilterRunner(next, filters_plugins)
+		go func() {
+			err := runner.Run()
+			if err != nil {
+				logp.Critical("Filters runner failed: %v", err)
+				// shutting down
+				stopCb()
+			}
+		}()
+		input = runner.FiltersQueue
+	} else {
+		input = next
+	}
+
+	return input, nil
+}

--- a/filters/filters_runner_test.go
+++ b/filters/filters_runner_test.go
@@ -1,0 +1,175 @@
+package filters
+
+import (
+	"testing"
+
+	"github.com/elastic/libbeat/common"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Nop filter for testing purposes
+type Nop struct {
+	name string
+}
+
+func (nop *Nop) New(name string, config map[string]interface{}) (FilterPlugin, error) {
+	return &Nop{name: name}, nil
+}
+
+func (nop *Nop) Filter(event common.MapStr) (common.MapStr, error) {
+	return event, nil
+}
+
+func (nop *Nop) String() string {
+	return nop.name
+}
+
+func (nop *Nop) Type() Filter {
+	return NopFilter
+}
+
+func loadPlugins() {
+	Filters.Register(NopFilter, new(Nop))
+}
+
+func TestFilterRunner(t *testing.T) {
+	loadPlugins()
+
+	output := make(chan common.MapStr, 10)
+
+	filter1, err := new(Nop).New("nop1", map[string]interface{}{})
+	assert.Nil(t, err)
+
+	filter2, err := new(Nop).New("nop2", map[string]interface{}{})
+	assert.Nil(t, err)
+
+	runner := NewFilterRunner(output, []FilterPlugin{filter1, filter2})
+	assert.NotNil(t, runner)
+
+	go runner.Run()
+
+	runner.FiltersQueue <- common.MapStr{"hello": "world"}
+	runner.FiltersQueue <- common.MapStr{"foo": "bar"}
+
+	res := <-output
+	assert.Equal(t, common.MapStr{"hello": "world"}, res)
+
+	res = <-output
+	assert.Equal(t, common.MapStr{"foo": "bar"}, res)
+}
+
+func TestLoadConfiguredFilters(t *testing.T) {
+	loadPlugins()
+
+	type o struct {
+		Name string
+		Type Filter
+	}
+
+	type io struct {
+		Input  map[string]interface{}
+		Output []o
+	}
+
+	tests := []io{
+		// should find configuration by types
+		io{
+			Input: map[string]interface{}{
+				"filters": []interface{}{"nop1", "nop2"},
+				"nop1": map[interface{}]interface{}{
+					"type": "nop",
+				},
+				"nop2": map[interface{}]interface{}{
+					"type": "nop",
+				},
+			},
+			Output: []o{
+				o{
+					Name: "nop1",
+					Type: NopFilter,
+				},
+				o{
+					Name: "nop2",
+					Type: NopFilter,
+				},
+			},
+		},
+		// should work with implicit configuration by name
+		io{
+			Input: map[string]interface{}{
+				"filters": []interface{}{"nop", "sample1"},
+				"sample1": map[interface{}]interface{}{
+					"type": "nop",
+				},
+			},
+			Output: []o{
+				o{
+					Name: "nop",
+					Type: NopFilter,
+				},
+				o{
+					Name: "sample1",
+					Type: NopFilter,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		res, err := LoadConfiguredFilters(test.Input)
+		assert.Nil(t, err)
+
+		res_o := []o{}
+		for _, r := range res {
+			res_o = append(res_o, o{Name: r.String(), Type: r.Type()})
+		}
+
+		assert.Equal(t, test.Output, res_o)
+	}
+}
+
+func TestLoadConfiguredFiltersNegative(t *testing.T) {
+	loadPlugins()
+
+	type io struct {
+		Input map[string]interface{}
+		Err   string
+	}
+
+	tests := []io{
+		io{
+			Input: map[string]interface{}{
+				"filters": []interface{}{"nop1", "nop2"},
+				"nop1": map[interface{}]interface{}{
+					"type": "nop",
+				},
+			},
+			Err: "No such filter type and no corresponding configuration: nop2",
+		},
+		io{
+			Input: map[string]interface{}{
+				"filters": []interface{}{"nop1", "nop"},
+				"nop1": map[interface{}]interface{}{
+					"hype": "nop",
+				},
+			},
+			Err: "Couldn't get type for filter: nop1",
+		},
+		io{
+			Input: map[string]interface{}{
+				"filters": []interface{}{"nop1", "nop"},
+				"nop1": map[interface{}]interface{}{
+					"type": 1,
+				},
+			},
+			Err: "Couldn't get type for filter: nop1",
+		},
+	}
+
+	for _, test := range tests {
+		_, err := LoadConfiguredFilters(test.Input)
+		assert.NotNil(t, err)
+		assert.Equal(t, test.Err, err.Error())
+	}
+}

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -187,6 +187,12 @@ func TestEvents(t *testing.T) {
 	event["redis"] = r
 
 	index := fmt.Sprintf("%s-%d.%02d.%02d", elasticsearchOutput.Index, ts.Year(), ts.Month(), ts.Day())
+	elasticsearchOutput.Conn.CreateIndex(index, common.MapStr{
+		"settings": common.MapStr{
+			"number_of_shards":   1,
+			"number_of_replicas": 0,
+		},
+	})
 
 	err := elasticsearchOutput.PublishEvent(ts, event)
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -1,8 +1,12 @@
 package service
 
 import (
+	"flag"
+	"log"
 	"os"
 	"os/signal"
+	"runtime"
+	"runtime/pprof"
 	"syscall"
 
 	"github.com/elastic/libbeat/logp"
@@ -26,4 +30,64 @@ func HandleSignals(stopFunction func()) {
 		logp.Debug("service", "Received svc stop/shutdown request")
 		stopFunction()
 	})
+}
+
+// cmdline flags
+var memprofile, cpuprofile *string
+
+func CmdLineFlags(flags *flag.FlagSet) {
+	memprofile = flags.String("memprofile", "", "Write memory profile to this file")
+	cpuprofile = flags.String("cpuprofile", "", "Write cpu profile to file")
+}
+
+func WithMemProfile() bool {
+	return *memprofile != ""
+}
+
+func WithCpuProfile() bool {
+	return *cpuprofile != ""
+}
+
+func BeforeRun() {
+
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+	}
+}
+
+func Cleanup() {
+	if *cpuprofile != "" {
+		pprof.StopCPUProfile()
+	}
+
+	if *memprofile != "" {
+		runtime.GC()
+
+		writeHeapProfile(*memprofile)
+
+		debugMemStats()
+	}
+}
+
+func debugMemStats() {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	logp.Debug("mem", "Memory stats: In use: %d Total (even if freed): %d System: %d",
+		m.Alloc, m.TotalAlloc, m.Sys)
+}
+
+func writeHeapProfile(filename string) {
+	f, err := os.Create(filename)
+	if err != nil {
+		logp.Err("Failed creating file %s: %s", filename, err)
+		return
+	}
+	pprof.WriteHeapProfile(f)
+	f.Close()
+
+	logp.Info("Created memory profile file %s.", filename)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/elastic/libbeat/logp"
+)
+
+// Handles OS signals that ask the service/daemon to stop.
+// The stopFunction should break the loop in the Beat so that
+// the service shut downs gracefully.
+func HandleSignals(stopFunction func()) {
+	// On ^C or SIGTERM, gracefully stop the sniffer
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigc
+		logp.Debug("service", "Received sigterm/sigint, stopping")
+		stopFunction()
+	}()
+
+	// Handle the Windows service events
+	go ProcessWindowsControlEvents(func() {
+		logp.Debug("service", "Received svc stop/shutdown request")
+		stopFunction()
+	})
+}


### PR DESCRIPTION
This moves some boilerplate that used to be in the `main()` of Packetbeat into libbeat. The boilerplate deals with flags like `-c` for command line flags, `-cpuprofie/-memprofile`, with signal handling with parsing the configuration file etc.

The point of this, besides removing code duplication between Beats is to have them all behave identically.