### PR TITLE
Feature/protocol helpers1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+*.test

--- a/common/mapstr.go
+++ b/common/mapstr.go
@@ -9,6 +9,12 @@ import (
 // Commonly used map of things, used in JSON creation and the like.
 type MapStr map[string]interface{}
 
+// Eventer defines a type its ability to fill a MapStr.
+type Eventer interface {
+	// Add fields to MapStr.
+	Event(event MapStr) error
+}
+
 // MapStrUnion creates a new MapStr containing the union of the
 // key-value pairs of the two maps. If the same key is present in
 // both, the key-value pairs from dict2 overwrite the ones from dict1.

--- a/common/statuses.go
+++ b/common/statuses.go
@@ -2,6 +2,8 @@ package common
 
 // standardized status values
 const (
-	OK_STATUS    = "OK"
-	ERROR_STATUS = "Error"
+	OK_STATUS           = "OK"
+	ERROR_STATUS        = "Error"
+	SERVER_ERROR_STATUS = "Server Error"
+	CLIENT_ERROR_STATUS = "Client Error"
 )

--- a/common/streambuf/ascii.go
+++ b/common/streambuf/ascii.go
@@ -1,0 +1,212 @@
+package streambuf
+
+// ASCII parsing support
+
+import (
+	"bytes"
+	"errors"
+)
+
+var ErrExpectedDigit = errors.New("Expected digit")
+
+// UntilCRLF collects all bytes until a CRLF ("\r\n") sequence is found. The
+// returned byte slice will not contain the CRLF sequence.
+// If CRLF was not found yet one of ErrNoMoreBytes or ErrUnexpectedEOB will be
+// reported.
+func (b *Buffer) UntilCRLF() ([]byte, error) {
+	if b.Failed() {
+		return nil, b.err
+	}
+
+	data := b.data[b.offset:]
+	for i, byte := range data {
+		if byte != '\r' {
+			continue
+		}
+
+		if len(data) < i+2 {
+			b.offset += i
+			return nil, b.bufferEndError()
+		}
+
+		if data[i+1] != '\n' {
+			// false alarm, continue
+			continue
+		}
+
+		// yay, found
+		end := i
+		data = b.data[b.mark : b.offset+end]
+		b.Advance(len(data) + 2)
+		return data, nil
+	}
+
+	b.offset += len(data)
+	return nil, b.bufferEndError()
+}
+
+// Ignore symbol will advance the read pointer until the first symbol not
+// matching s is found.
+func (b *Buffer) IgnoreSymbol(s uint8) error {
+	if b.Failed() {
+		return b.err
+	}
+
+	data := b.data[b.offset:]
+	for i, byte := range data {
+		if byte != s {
+			b.Advance(b.offset + i - b.mark)
+			return nil
+		}
+	}
+	b.offset += len(data)
+	return b.bufferEndError()
+}
+
+// UntilSymbol collects all bytes until symbol s is found. If errOnEnd is set to
+// true, the collected byte slice will be returned if no more bytes are available
+// for parsing, but s has not matched yet.
+func (b *Buffer) UntilSymbol(s uint8, errOnEnd bool) ([]byte, error) {
+	if b.Failed() {
+		return nil, b.err
+	}
+
+	data := b.data[b.offset:]
+	for i, byte := range data {
+		if byte == s {
+			data := b.data[b.mark : b.offset+i]
+			b.Advance(len(data))
+			return data, nil
+		}
+	}
+
+	if errOnEnd {
+		b.offset += len(data)
+		return nil, b.bufferEndError()
+	} else {
+		data := b.data[b.mark:]
+		b.Advance(len(data))
+		return data, nil
+	}
+}
+
+// AsciiUint will parse unsigned number from Buffer.
+func (b *Buffer) AsciiUint(errOnEnd bool) (uint64, error) {
+	if b.Failed() {
+		return 0, b.err
+	}
+	if len(b.data) <= b.mark { // end of buffer
+		return 0, b.bufferEndError()
+	}
+
+	end, err := b.asciiFindNumberEnd(b.offset, errOnEnd)
+	if err != nil {
+		return 0, err
+	}
+
+	// parse value
+	value, err := doParseNumber(b.data[b.mark:end])
+	if err != nil {
+		return 0, err
+	}
+	b.Advance(end - b.mark)
+	return value, nil
+}
+
+// AsciiInt will parse (optionally) signed number from Buffer.
+func (b *Buffer) AsciiInt(errOnEnd bool) (int64, error) {
+	if b.Failed() {
+		return 0, b.err
+	}
+	if len(b.data) <= b.mark { // end of buffer
+		return 0, b.bufferEndError()
+	}
+
+	// check signedness of number
+	signed := b.data[b.mark] == '-'
+	start := b.mark
+	if signed {
+		start++
+		if len(b.data) <= start {
+			return 0, b.bufferEndError()
+		}
+	} else if b.data[b.mark] == '+' {
+		start++
+		if len(b.data) <= start {
+			return 0, b.bufferEndError()
+		}
+	}
+
+	// adapt offset to point to start of number
+	offset := b.offset
+	if b.offset == b.mark {
+		offset = start
+	}
+
+	end, err := b.asciiFindNumberEnd(offset, errOnEnd)
+	if err != nil {
+		return 0, err
+	}
+
+	value, err := doParseNumber(b.data[start:end])
+	if err != nil {
+		return 0, err
+	}
+
+	b.Advance(end - b.mark)
+	if signed {
+		return -int64(value), nil
+	} else {
+		return int64(value), nil
+	}
+}
+
+// AsciiMatch checks the Buffer it's next byte sequence matched prefix. The
+// read pointer is not advanced by AsciiPrefix.
+func (b *Buffer) AsciiMatch(prefix []byte) (bool, error) {
+	if b.Failed() {
+		return false, b.err
+	}
+	if !b.Avail(len(prefix)) {
+		return false, b.bufferEndError()
+	}
+
+	has := bytes.HasPrefix(b.data[b.mark:], prefix)
+	return has, nil
+}
+
+func (b *Buffer) asciiFindNumberEnd(start int, errOnEnd bool) (int, error) {
+	// find end of number
+	end := -1
+	for i, byte := range b.data[start:] {
+		if byte < '0' || '9' < byte {
+			end = i + start
+			break
+		}
+	}
+
+	// check end
+	if end < 0 {
+		if errOnEnd {
+			return -1, b.bufferEndError()
+		} else {
+			end = len(b.data)
+		}
+	}
+
+	return end, nil
+}
+
+func doParseNumber(buf []byte) (uint64, error) {
+	if len(buf) == 0 {
+		return 0, ErrExpectedDigit
+	}
+
+	var value uint64
+	for _, byte := range buf {
+		value = uint64(byte-'0') + 10*value
+	}
+	return value, nil
+}
+
+// binary parsing support

--- a/common/streambuf/ascii_test.go
+++ b/common/streambuf/ascii_test.go
@@ -1,0 +1,291 @@
+package streambuf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_UntilCRLFOK(t *testing.T) {
+	b := New([]byte("  test\r\n"))
+	b.Advance(2)
+	d, err := b.UntilCRLF()
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.False(t, b.Failed())
+	assert.Equal(t, d, []byte("test"))
+	assert.Equal(t, 0, b.Len())
+}
+
+func Test_UntilCRLFFailed(t *testing.T) {
+	b := New([]byte("  test\r\nabc"))
+	b.SetError(ErrTest)
+	_, err := b.UntilCRLF()
+	assert.Equal(t, ErrTest, err)
+}
+
+func Test_UntilCRLFCont(t *testing.T) {
+	b := New([]byte("  test"))
+	b.Advance(2)
+
+	_, err := b.UntilCRLF()
+	assert.Equal(t, ErrNoMoreBytes, err)
+
+	err = b.Append([]byte("\r\nabc"))
+	assert.Nil(t, err)
+	assert.False(t, b.Failed())
+	assert.Equal(t, 4, b.LeftBehind())
+
+	d, err := b.UntilCRLF()
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.False(t, b.Failed())
+	assert.Equal(t, d, []byte("test"))
+	assert.Equal(t, 3, b.Len())
+}
+
+func Test_UntilCRLFOnlyCRThenCRLF(t *testing.T) {
+	b := New([]byte("test\rtest\r\nabc"))
+	d, err := b.UntilCRLF()
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.False(t, b.Failed())
+	assert.Equal(t, d, []byte("test\rtest"))
+	assert.Equal(t, 3, b.Len())
+}
+
+func Test_UntilCRLFOnlyCRThenCRLFWithCont(t *testing.T) {
+	b := New([]byte("test\rtest\r"))
+
+	_, err := b.UntilCRLF()
+	assert.Equal(t, ErrNoMoreBytes, err)
+
+	err = b.Append([]byte("\nabc"))
+	assert.Nil(t, err)
+	assert.False(t, b.Failed())
+	assert.Equal(t, 9, b.LeftBehind())
+
+	d, err := b.UntilCRLF()
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.False(t, b.Failed())
+	assert.Equal(t, d, []byte("test\rtest"))
+	assert.Equal(t, 3, b.Len())
+}
+
+func Test_IgnoreSymbolOK(t *testing.T) {
+	b := New([]byte("  test"))
+	err := b.IgnoreSymbol(' ')
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.False(t, b.Failed())
+	assert.Equal(t, 4, b.Len())
+}
+
+func Test_IgnoreSymbolFailed(t *testing.T) {
+	b := New([]byte("  test"))
+	b.SetError(ErrTest)
+	err := b.IgnoreSymbol(' ')
+	assert.Equal(t, ErrTest, err)
+}
+
+func Test_IgnoreSymbolCont(t *testing.T) {
+	b := New([]byte("    "))
+
+	err := b.IgnoreSymbol(' ')
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Equal(t, 4, b.LeftBehind())
+
+	b.Append([]byte("  test"))
+	err = b.IgnoreSymbol(' ')
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.False(t, b.Failed())
+	assert.Equal(t, 4, b.Len())
+}
+
+func Test_UntilSymbolOK(t *testing.T) {
+	b := New([]byte("test "))
+	d, err := b.UntilSymbol(' ', true)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("test"), d)
+}
+
+func Test_UntilSymbolFailed(t *testing.T) {
+	b := New([]byte("test "))
+	b.SetError(ErrTest)
+	_, err := b.UntilSymbol(' ', true)
+	assert.Equal(t, ErrTest, err)
+}
+
+func Test_UntilSymbolCont(t *testing.T) {
+	b := New([]byte("tes"))
+
+	_, err := b.UntilSymbol(' ', true)
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Equal(t, 3, b.LeftBehind())
+
+	b.Append([]byte("t "))
+	d, err := b.UntilSymbol(' ', true)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("test"), d)
+}
+
+func Test_UntilSymbolOrEnd(t *testing.T) {
+	b := New([]byte("test"))
+	d, err := b.UntilSymbol(' ', false)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("test"), d)
+}
+
+func Test_AsciiUintOK(t *testing.T) {
+	b := New([]byte("123 "))
+	v, err := b.AsciiUint(false)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(123), v)
+}
+
+func Test_AsciiUintFailed(t *testing.T) {
+	b := New([]byte("123 "))
+	b.SetError(ErrTest)
+	_, err := b.AsciiUint(false)
+	assert.Equal(t, ErrTest, err)
+}
+
+func Test_AsciiUintNotDigit(t *testing.T) {
+	b := New([]byte("test"))
+	_, err := b.AsciiUint(false)
+	assert.Equal(t, ErrExpectedDigit, err)
+}
+
+func Test_AsciiUintEmpty(t *testing.T) {
+	b := New([]byte(""))
+	_, err := b.AsciiUint(false)
+	assert.Equal(t, ErrNoMoreBytes, err)
+}
+
+func Test_AsciiUintCont(t *testing.T) {
+	b := New([]byte("12"))
+	_, err := b.AsciiUint(true)
+	assert.Equal(t, ErrNoMoreBytes, err)
+
+	b.Append([]byte("34 "))
+	v, err := b.AsciiUint(true)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(1234), v)
+}
+
+func Test_AsciiUintOrEndOK(t *testing.T) {
+	b := New([]byte("12"))
+	v, err := b.AsciiUint(false)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(12), v)
+}
+
+func Test_AsciiIntOK(t *testing.T) {
+	b := New([]byte("123 "))
+	v, err := b.AsciiInt(false)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(123), v)
+}
+
+func Test_AsciiIntPosOK(t *testing.T) {
+	b := New([]byte("+123 "))
+	v, err := b.AsciiInt(false)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(123), v)
+}
+
+func Test_AsciiIntNegOK(t *testing.T) {
+	b := New([]byte("-123 "))
+	v, err := b.AsciiInt(false)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(-123), v)
+}
+
+func Test_AsciiIntFailed(t *testing.T) {
+	b := New([]byte("123 "))
+	b.SetError(ErrTest)
+	_, err := b.AsciiInt(false)
+	assert.Equal(t, ErrTest, err)
+}
+
+func Test_AsciiIntNotDigit(t *testing.T) {
+	b := New([]byte("test"))
+	_, err := b.AsciiInt(false)
+	assert.Equal(t, ErrExpectedDigit, err)
+}
+
+func Test_AsciiIntEmpty(t *testing.T) {
+	b := New([]byte(""))
+	_, err := b.AsciiInt(false)
+	assert.Equal(t, ErrNoMoreBytes, err)
+}
+
+func Test_AsciiIntCont(t *testing.T) {
+	b := New([]byte("12"))
+	_, err := b.AsciiInt(true)
+	assert.Equal(t, ErrNoMoreBytes, err)
+
+	b.Append([]byte("34 "))
+	v, err := b.AsciiInt(true)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1234), v)
+}
+
+func Test_AsciiIntOrEndOK(t *testing.T) {
+	b := New([]byte("12"))
+	v, err := b.AsciiInt(false)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(12), v)
+}
+
+func Test_AsciiMatchOK(t *testing.T) {
+	b := New([]byte("match test"))
+	r, err := b.AsciiMatch([]byte("match"))
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.True(t, r)
+	assert.Equal(t, 10, b.Len()) // check no bytes consumed
+}
+
+func Test_AsciiMatchNo(t *testing.T) {
+	b := New([]byte("match test"))
+	r, err := b.AsciiMatch([]byte("batch"))
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.False(t, r)
+	assert.Equal(t, 10, b.Len()) // check no bytes consumed
+}
+
+func Test_AsciiMatchCont(t *testing.T) {
+	b := New([]byte("mat"))
+
+	_, err := b.AsciiMatch([]byte("match"))
+	assert.Equal(t, ErrNoMoreBytes, err)
+
+	b.Append([]byte("ch test"))
+	r, err := b.AsciiMatch([]byte("match"))
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.True(t, r)
+	assert.Equal(t, 10, b.Len()) // check no bytes consumed
+}
+
+func Test_AsciiMatchFailed(t *testing.T) {
+	b := New([]byte("match test"))
+	b.SetError(ErrTest)
+	_, err := b.AsciiMatch([]byte("match"))
+	assert.Equal(t, ErrTest, err)
+}

--- a/common/streambuf/io.go
+++ b/common/streambuf/io.go
@@ -1,0 +1,187 @@
+package streambuf
+
+import (
+	"io"
+	"unicode/utf8"
+)
+
+func (b *Buffer) ioErr() error {
+	err := b.Err()
+	if err == ErrUnexpectedEOB || err == ErrNoMoreBytes {
+		return io.EOF
+	}
+	return err
+}
+
+func (b *Buffer) ioBufferEndError() error {
+	err := b.bufferEndError()
+	if err == ErrUnexpectedEOB || err == ErrNoMoreBytes {
+		return io.EOF
+	}
+	return err
+}
+
+// ReadByte reads and returns next byte from the buffer.
+// If no byte is available returns either ErrNoMoreBytes (if buffer allows
+// adding more bytes) or io.EOF
+func (b *Buffer) ReadByte() (byte, error) {
+	if b.Failed() {
+		return 0, b.ioErr()
+	}
+	if !b.Avail(1) {
+		return 0, b.ioBufferEndError()
+	}
+	c := b.data[b.mark]
+	b.Advance(1)
+	return c, nil
+}
+
+// Unreads the last byte returned by most recent read operation.
+func (b *Buffer) UnreadByte() error {
+	err := b.ioErr()
+	if err != nil && err != io.EOF {
+		return err
+	}
+	if b.mark == 0 {
+		return ErrOutOfRange
+	}
+
+	if b.mark == b.offset {
+		b.offset--
+	}
+	b.mark--
+	b.available++
+	return nil
+}
+
+// WriteByte appends the byte c to the buffer if buffer is not fixed.
+func (b *Buffer) WriteByte(c byte) error {
+	p := [1]byte{c}
+	_, err := b.Write(p[:])
+	return err
+}
+
+// Read reads up to len(p) bytes into p if buffer is not in a failed state.
+// Returns ErrNoMoreBytes or io.EOF (fixed buffer) if no bytes are available.
+func (b *Buffer) Read(p []byte) (int, error) {
+	if b.Failed() {
+		return 0, b.ioErr()
+	}
+	if b.Len() == 0 {
+		return 0, b.ioBufferEndError()
+	}
+
+	tmp := b.Bytes()
+	n := copy(p, tmp)
+	b.Advance(n)
+	return n, nil
+}
+
+// Write writes p to the buffer if buffer is not fixed. Returns the number of
+// bytes written or ErrOperationNotAllowed if buffer is fixed.
+func (b *Buffer) Write(p []byte) (int, error) {
+	err := b.doAppend(p, false)
+	if err != nil {
+		return 0, b.ioErr()
+	}
+	return len(p), nil
+}
+
+// ReadFrom reads data from r until error or io.EOF and appends it to the buffer.
+// The amount of bytes read is returned plus any error except io.EOF.
+func (b *Buffer) ReadFrom(r io.Reader) (int64, error) {
+	err := b.err
+	if err != nil && err != ErrNoMoreBytes {
+		return 0, b.ioErr()
+	}
+	if b.fixed {
+		return 0, ErrOperationNotAllowed
+	}
+
+	var buf [4096]byte
+	var total int64
+	for {
+		n, err := r.Read(buf[:])
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return total, err
+		}
+		_, err = b.Write(buf[:n])
+		if err != nil {
+			return total, err
+		}
+		total += int64(n)
+	}
+
+	return total, nil
+}
+
+// ReadRune reads and returns the next UTF-8-encoded Unicode code point from the
+// buffer. If no bytes are available, the error returned is ErrNoMoreBytes (if
+// buffer supports adding more bytes) or io.EOF. If the bytes are an erroneous
+// UTF-8 encoding, it consumes one byte and returns U+FFFD, 1.
+func (b *Buffer) ReadRune() (rune, int, error) {
+	if b.err != nil {
+		return 0, 0, b.ioErr()
+	}
+	if b.available == 0 {
+		return 0, 0, b.ioBufferEndError()
+	}
+
+	if c := b.data[b.mark]; c < utf8.RuneSelf {
+		b.Advance(1)
+		return rune(c), 1, nil
+	}
+	c, size := utf8.DecodeRune(b.data[b.mark:])
+	b.Advance(size)
+	return c, size, nil
+}
+
+// ReadAt reads bytes at off into p starting at the buffer its read marker.
+// The read marker is not updated. If number of bytes returned is less len(p) or
+// no bytes are available at off, io.EOF will be returned in err. If off is < 0,
+// err is set to ErrOutOfRange.
+func (b *Buffer) ReadAt(p []byte, off int64) (n int, err error) {
+	if b.err != nil {
+		return 0, b.ioErr()
+	}
+
+	if off < 0 {
+		return 0, ErrOutOfRange
+	}
+
+	off += int64(b.mark)
+	if off >= int64(len(b.data)) {
+		return 0, ErrOutOfRange
+	}
+
+	end := off + int64(len(p))
+	if end > int64(len(b.data)) {
+		err = io.EOF
+		end = int64(len(b.data))
+	}
+	copy(p, b.data[off:end])
+	return int(end - off), err
+}
+
+// WriteAt writes the content of p at off starting at recent read marker
+// (already consumed bytes). Returns number of bytes written n = len(p) and err
+// is nil if off and off+len(p) are within bounds, else n=0 and err is set to
+// ErrOutOfRange.
+func (b *Buffer) WriteAt(p []byte, off int64) (n int, err error) {
+	if b.err != nil {
+		return 0, b.ioErr()
+	}
+
+	end := off + int64(b.mark) + int64(len(p))
+	maxInt := int((^uint(0)) >> 1)
+	if off < 0 || end > int64(maxInt) {
+		return 0, ErrOutOfRange
+	}
+
+	// copy p into buffer
+	n = copy(b.sliceAt(int(off), len(p)), p)
+	return n, nil
+}

--- a/common/streambuf/io_test.go
+++ b/common/streambuf/io_test.go
@@ -1,0 +1,328 @@
+package streambuf
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ImplementsInterfaces(t *testing.T) {
+	b := New(nil)
+	var _ io.Reader = b
+	var _ io.Writer = b
+	var _ io.ReadWriter = b
+	var _ io.ReaderFrom = b
+	var _ io.ByteReader = b
+	var _ io.ByteScanner = b
+	var _ io.ByteWriter = b
+	var _ io.RuneReader = b
+}
+
+func Test_ReadByteEOFCheck(t *testing.T) {
+	b := New(nil)
+	n, err := b.ReadByte()
+	assert.Equal(t, byte(0), n)
+	assert.Equal(t, io.EOF, err)
+
+	b = New(nil)
+	b.SetError(ErrNoMoreBytes)
+	n, err = b.ReadByte()
+	assert.Equal(t, byte(0), n)
+	assert.Equal(t, io.EOF, err)
+
+	b = New(nil)
+	b.SetError(ErrUnexpectedEOB)
+	n, err = b.ReadByte()
+	assert.Equal(t, byte(0), n)
+	assert.Equal(t, io.EOF, err)
+
+	b = New(nil)
+	b.SetError(ErrTest)
+	n, err = b.ReadByte()
+	assert.Equal(t, byte(0), n)
+	assert.Equal(t, ErrTest, err)
+}
+
+func Test_ReadByteOK(t *testing.T) {
+	b := New([]byte{1})
+	v, err := b.ReadByte()
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, byte(1), v)
+
+	_, err = b.ReadByte()
+	assert.Equal(t, io.EOF, err)
+}
+
+func Test_ReadUnreadByteOK(t *testing.T) {
+	b := New([]byte{1, 2})
+	v, err := b.ReadByte()
+	b.checkInvariants(t)
+	assert.Equal(t, byte(1), v)
+	assert.Nil(t, err)
+
+	err = b.UnreadByte()
+	assert.Nil(t, err)
+	assert.Equal(t, 2, b.Len())
+}
+
+func Test_ReadUnreadByteErrCheck(t *testing.T) {
+	b := New(nil)
+	b.SetError(ErrTest)
+	err := b.UnreadByte()
+	b.checkInvariants(t)
+	assert.Equal(t, ErrTest, err)
+}
+
+func Test_UnreadByteFail(t *testing.T) {
+	b := New(nil)
+	err := b.UnreadByte()
+	b.checkInvariants(t)
+	assert.Equal(t, ErrOutOfRange, err)
+}
+
+func Test_UnreadAfterEOFOK(t *testing.T) {
+	b := New([]byte{1})
+
+	b.ReadByte()
+	_, err := b.ReadByte()
+	assert.Equal(t, io.EOF, err)
+
+	err = b.UnreadByte()
+	assert.Nil(t, err)
+}
+
+func Test_WriteByte(t *testing.T) {
+	b := New(nil)
+
+	err := b.WriteByte(1)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, b.Len())
+	assert.Equal(t, byte(1), b.Bytes()[0])
+}
+
+func Test_WriteByteEOFCheck(t *testing.T) {
+	b := New(nil)
+
+	_, err := b.ReadByte()
+	assert.Equal(t, io.EOF, err)
+
+	err = b.WriteByte(1)
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+}
+
+func Test_WriteByteFixedFail(t *testing.T) {
+	b := NewFixed(nil)
+	err := b.WriteByte(1)
+	b.checkInvariants(t)
+	assert.Equal(t, ErrOperationNotAllowed, err)
+}
+
+func Test_ReadBufSmaller(t *testing.T) {
+	b := New([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	tmp := make([]byte, 5)
+
+	n, err := b.Read(tmp)
+	b.checkInvariants(t)
+	assert.Equal(t, 5, n)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{1, 2, 3, 4, 5}, tmp[:n])
+
+	n, err = b.Read(tmp)
+	b.checkInvariants(t)
+	assert.Equal(t, 3, n)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{6, 7, 8}, tmp[:n])
+
+	n, err = b.Read(tmp)
+	assert.Equal(t, io.EOF, err)
+}
+
+func Test_ReadBufBigger(t *testing.T) {
+	b := New([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	tmp := make([]byte, 10)
+
+	n, err := b.Read(tmp)
+	b.checkInvariants(t)
+	assert.Equal(t, 8, n)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{1, 2, 3, 4, 5, 6, 7, 8}, tmp[:n])
+
+	n, err = b.Read(tmp)
+	assert.Equal(t, io.EOF, err)
+}
+
+func Test_ReadOnFailed(t *testing.T) {
+	b := New([]byte{1, 2, 3})
+	b.SetError(ErrTest)
+	tmp := make([]byte, 10)
+	_, err := b.Read(tmp)
+	assert.Equal(t, ErrTest, err)
+}
+
+func Test_WriteOK(t *testing.T) {
+	b := New(nil)
+	n, err := b.Write([]byte{1, 2, 3})
+	b.checkInvariants(t)
+	assert.Equal(t, 3, n)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, b.Len())
+}
+
+func Test_WriteDoesNotRetain(t *testing.T) {
+	tmp := []byte{1, 2, 3}
+
+	b := New(nil)
+	n, err := b.Write(tmp)
+	b.checkInvariants(t)
+	assert.Equal(t, 3, n)
+	assert.Nil(t, err)
+
+	b.Bytes()[0] = 'a'
+	assert.Equal(t, byte(1), tmp[0])
+}
+
+func Test_WriteFail(t *testing.T) {
+	b := New(nil)
+	b.SetError(ErrTest)
+	_, err := b.Write([]byte{1})
+	assert.Equal(t, ErrTest, err)
+}
+
+func Test_WriteNil(t *testing.T) {
+	b := New([]byte{1, 2, 3})
+	n, err := b.Write(nil)
+	assert.Equal(t, 0, n)
+	assert.Nil(t, err)
+}
+
+func Test_ReadFromOK(t *testing.T) {
+	b := New(nil)
+	from := New([]byte{1, 2, 3, 4})
+
+	n, err := b.ReadFrom(from)
+	assert.Equal(t, int64(4), n)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{1, 2, 3, 4}, b.Bytes())
+
+	// check buffers are not retained
+	b.Bytes()[0] = 'a'
+	assert.Equal(t, byte(1), from.BufferedBytes()[0])
+
+	// check from is really eof
+	_, err = from.ReadByte()
+	assert.Equal(t, io.EOF, err)
+}
+
+func Test_ReadFromIfEOF(t *testing.T) {
+	b := New(nil)
+	from := New([]byte{1, 2, 3, 4})
+
+	// move buffer into EOF state
+	_, err := b.ReadByte()
+	assert.Equal(t, io.EOF, err)
+
+	// copy from
+	n, err := b.ReadFrom(from)
+	assert.Equal(t, int64(4), n)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{1, 2, 3, 4}, b.Bytes())
+
+	// check buffers are not retained
+	b.Bytes()[0] = 'a'
+	assert.Equal(t, byte(1), from.BufferedBytes()[0])
+
+	// check from is really eof
+	_, err = from.ReadByte()
+	assert.Equal(t, io.EOF, err)
+}
+
+func Test_ReadFromFailOnFixed(t *testing.T) {
+	b := NewFixed(nil)
+	from := NewFixed([]byte{1, 2, 3, 4})
+
+	n, err := b.ReadFrom(from)
+	assert.Equal(t, int64(0), n)
+	assert.Equal(t, err, ErrOperationNotAllowed)
+}
+
+func Test_ReadRuneOK(t *testing.T) {
+	b := New([]byte("xäüö"))
+	r, s, err := b.ReadRune()
+	assert.Nil(t, err)
+	assert.Equal(t, 'x', r)
+	assert.Equal(t, 1, s)
+
+	r, s, err = b.ReadRune()
+	assert.Nil(t, err)
+	assert.Equal(t, 'ä', r)
+	assert.Equal(t, 2, s)
+}
+
+func Test_ReadRuneEOFCheck(t *testing.T) {
+	b := New(nil)
+	_, _, err := b.ReadRune()
+	assert.Equal(t, io.EOF, err)
+}
+
+func Test_ReadRuneFailed(t *testing.T) {
+	b := New(nil)
+	b.SetError(ErrTest)
+	_, _, err := b.ReadRune()
+	assert.Equal(t, ErrTest, err)
+}
+
+func Test_ReadAtOK(t *testing.T) {
+	b := New([]byte{1, 2, 3, 4})
+	b.Advance(1)
+
+	tmp := make([]byte, 2)
+	n, err := b.ReadAt(tmp, 1)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, []byte{3, 4}, tmp[:n])
+
+	n, err = b.ReadAt(tmp, 2)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, []byte{4}, tmp[:n])
+}
+
+func Test_ReadAtOutOfRange(t *testing.T) {
+	b := New([]byte{1, 2, 3, 4})
+	b.Advance(1)
+
+	tmp := make([]byte, 2)
+	_, err := b.ReadAt(tmp, -1)
+	assert.Equal(t, ErrOutOfRange, err)
+
+	_, err = b.ReadAt(tmp, 10)
+	assert.Equal(t, ErrOutOfRange, err)
+}
+
+func Test_WriteAtToNil(t *testing.T) {
+	b := New(nil)
+	n, err := b.WriteAt([]byte{1, 2, 3}, 4)
+	assert.Equal(t, 3, n)
+	assert.Nil(t, err)
+}
+
+func Test_WriteAtOverwrites(t *testing.T) {
+	b := New([]byte{'a', 'b', 'c', 'd', 'e'})
+	b.Advance(1)
+	n, err := b.WriteAt([]byte{1, 2, 3}, 1)
+	assert.Equal(t, 3, n)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{'b', 1, 2, 3}, b.Bytes())
+
+	b = New(make([]byte, 3, 20))
+	b.Advance(2)
+	n, err = b.WriteAt([]byte{1, 2, 3}, 1)
+	assert.Equal(t, 3, n)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, b.Len())
+	// assert.Equal(t, []byte{0, 1, 2, 3}, b.Bytes())
+}

--- a/common/streambuf/net.go
+++ b/common/streambuf/net.go
@@ -1,0 +1,183 @@
+package streambuf
+
+// read integers in network byte order
+
+import (
+	"github.com/elastic/libbeat/common"
+)
+
+// Parse 8bit binary value from Buffer.
+func (b *Buffer) ReadNetUint8() (uint8, error) {
+	if b.Failed() {
+		return 0, b.err
+	}
+	tmp := b.data[b.mark:]
+	if err := b.Advance(1); err != nil {
+		return 0, err
+	}
+	value := tmp[0]
+	return value, nil
+}
+
+// Write 8bit binary value to Buffer.
+func (b *Buffer) WriteNetUint8(u uint8) error {
+	return b.Append([]byte{u})
+}
+
+// Parse 8bit binary value from the buffer at index. Will not advance the read
+// buffer
+func (b *Buffer) ReadNetUint8At(index int) (uint8, error) {
+	if b.Failed() {
+		return 0, b.err
+	}
+	if !b.Avail(1 + index) {
+		return 0, b.bufferEndError()
+	}
+	return b.data[index+b.mark], nil
+}
+
+// Write 8bit binary value at index.
+func (b *Buffer) WriteNetUint8At(u uint8, index int) error {
+	if b.err != nil {
+		return b.err
+	}
+	b.sliceAt(index, 1)[0] = u
+	return nil
+}
+
+// Parse 16bit binary value in network byte order from Buffer
+// (converted to Host order).
+func (b *Buffer) ReadNetUint16() (uint16, error) {
+	if b.Failed() {
+		return 0, b.err
+	}
+	tmp := b.data[b.mark:]
+	if err := b.Advance(2); err != nil {
+		return 0, err
+	}
+	value := common.Bytes_Ntohs(tmp)
+	return value, nil
+}
+
+// Write 16bit binary value in network byte order to buffer.
+func (b *Buffer) WriteNetUint16(u uint16) error {
+	return b.WriteNetUint16At(u, b.available)
+}
+
+// Parse 16bit binary value from the buffer at index. Will not advance the read
+// buffer
+func (b *Buffer) ReadNetUint16At(index int) (uint16, error) {
+	if b.Failed() {
+		return 0, b.err
+	}
+	if !b.Avail(2 + index) {
+		return 0, b.bufferEndError()
+	}
+	return common.Bytes_Ntohs(b.data[index+b.mark:]), nil
+
+}
+
+// Write 16bit binary value at index in network byte order to buffer.
+func (b *Buffer) WriteNetUint16At(u uint16, index int) error {
+	if b.err != nil {
+		return b.err
+	}
+	tmp := b.sliceAt(index, 2)
+	tmp[0] = uint8(u >> 8)
+	tmp[1] = uint8(u)
+	return nil
+}
+
+// Parse 32bit binary value in network byte order from Buffer
+// (converted to Host order).
+func (b *Buffer) ReadNetUint32() (uint32, error) {
+	if b.Failed() {
+		return 0, b.err
+	}
+	tmp := b.data[b.mark:]
+	if err := b.Advance(4); err != nil {
+		return 0, err
+	}
+	value := common.Bytes_Ntohl(tmp)
+	return value, nil
+}
+
+// Write 32bit binary value in network byte order to buffer.
+func (b *Buffer) WriteNetUint32(u uint32) error {
+	return b.WriteNetUint32At(u, b.available)
+}
+
+// Parse 32bit binary value from the buffer at index. Will not advance the read
+// buffer
+func (b *Buffer) ReadNetUint32At(index int) (uint32, error) {
+	if b.Failed() {
+		return 0, b.err
+	}
+	if !b.Avail(4 + index) {
+		return 0, b.bufferEndError()
+	}
+	return common.Bytes_Ntohl(b.data[index+b.mark:]), nil
+
+}
+
+// Write 32bit binary value at index in network byte order to buffer.
+func (b *Buffer) WriteNetUint32At(u uint32, index int) error {
+	if b.err != nil {
+		return b.err
+	}
+	tmp := b.sliceAt(index, 4)
+	tmp[0] = uint8(u >> 24)
+	tmp[1] = uint8(u >> 16)
+	tmp[2] = uint8(u >> 8)
+	tmp[3] = uint8(u)
+	return nil
+}
+
+// Parse 64bit binary value in network byte order from Buffer
+// (converted to Host order).
+func (b *Buffer) ReadNetUint64() (uint64, error) {
+	if b.Failed() {
+		return 0, b.err
+	}
+	tmp := b.data[b.mark:]
+	if err := b.Advance(8); err != nil {
+		return 0, err
+	}
+	value := common.Bytes_Ntohll(tmp)
+	return value, nil
+}
+
+// Write 64bit binary value in network byte order to buffer.
+func (b *Buffer) WriteNetUint64(u uint64) error {
+	return b.WriteNetUint64At(u, b.available)
+}
+
+// Parse 64bit binary value from the buffer at index. Will not advance the read
+// buffer
+func (b *Buffer) ReadNetUint64At(index int) (uint64, error) {
+	if b.Failed() {
+		return 0, b.err
+	}
+	if !b.Avail(8 + index) {
+		return 0, b.bufferEndError()
+	}
+	return common.Bytes_Ntohll(b.data[index+b.mark:]), nil
+
+}
+
+// Write 64bit binary value at index in network byte order to buffer.
+func (b *Buffer) WriteNetUint64At(u uint64, index int) error {
+	if b.err != nil {
+		return b.err
+	}
+	tmp := b.sliceAt(index, 8)
+	tmp[0] = uint8(u >> 56)
+	tmp[1] = uint8(u >> 48)
+	tmp[2] = uint8(u >> 40)
+	tmp[3] = uint8(u >> 32)
+	tmp[4] = uint8(u >> 24)
+	tmp[5] = uint8(u >> 16)
+	tmp[6] = uint8(u >> 8)
+	tmp[7] = uint8(u)
+	return nil
+}

--- a/common/streambuf/net_test.go
+++ b/common/streambuf/net_test.go
@@ -1,0 +1,239 @@
+package streambuf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ReadNetUint8NoData(t *testing.T) {
+	b := New(nil)
+	v, err := b.ReadNetUint8()
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Equal(t, uint8(0), v)
+}
+
+func Test_ReadNetUint8Failed(t *testing.T) {
+	b := New(nil)
+	b.SetError(ErrTest)
+	v, err := b.ReadNetUint8()
+	assert.Equal(t, ErrTest, err)
+	assert.Equal(t, uint8(0), v)
+}
+
+func Test_ReadNetUint8Data(t *testing.T) {
+	b := New([]byte{10})
+	v, err := b.ReadNetUint8()
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, uint8(10), v)
+}
+
+func Test_ReadNetUint8AtFailed(t *testing.T) {
+	b := New(nil)
+	b.SetError(ErrTest)
+	v, err := b.ReadNetUint8At(4)
+	assert.Equal(t, ErrTest, err)
+	assert.Equal(t, uint8(0), v)
+}
+
+func Test_ReadNetUint8AtInRange(t *testing.T) {
+	b := New([]byte{1, 2, 3})
+	v, err := b.ReadNetUint8At(2)
+	assert.Nil(t, err)
+	assert.Equal(t, uint8(3), v)
+}
+
+func Test_ReadNetUint8AtOutOfRange(t *testing.T) {
+	b := New([]byte{1, 2, 3})
+	v, err := b.ReadNetUint8At(3)
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Equal(t, uint8(0), v)
+}
+
+func Test_WriteNetUint8At(t *testing.T) {
+	b := New(nil)
+	err := b.WriteNetUint8At(10, 1)
+	assert.Nil(t, err)
+
+	b.Advance(1)
+	tmp, err := b.ReadNetUint8()
+	assert.Nil(t, err)
+	assert.Equal(t, uint8(10), tmp)
+}
+
+func Test_ReadNetUint16NoData(t *testing.T) {
+	b := New(nil)
+	v, err := b.ReadNetUint16()
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Equal(t, uint16(0), v)
+}
+
+func Test_ReadNetUint16Failed(t *testing.T) {
+	b := New(nil)
+	b.SetError(ErrTest)
+	v, err := b.ReadNetUint16()
+	assert.Equal(t, ErrTest, err)
+	assert.Equal(t, uint16(0), v)
+}
+
+func Test_ReadNetUint16Data(t *testing.T) {
+	b := New([]byte{0xf1, 0xf2})
+	v, err := b.ReadNetUint16()
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, uint16(0xf1f2), v)
+}
+
+func Test_ReadNetUint16AtFailed(t *testing.T) {
+	b := New(nil)
+	b.SetError(ErrTest)
+	v, err := b.ReadNetUint16At(4)
+	assert.Equal(t, ErrTest, err)
+	assert.Equal(t, uint16(0), v)
+}
+
+func Test_ReadNetUint16AtInRange(t *testing.T) {
+	b := New([]byte{0xf1, 0xf2, 0xf3})
+	v, err := b.ReadNetUint16At(1)
+	assert.Nil(t, err)
+	assert.Equal(t, uint16(0xf2f3), v)
+}
+
+func Test_ReadNetUint16AtOutOfRange(t *testing.T) {
+	b := New([]byte{0xf1, 0xf2, 0xf3})
+	v, err := b.ReadNetUint16At(2)
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Equal(t, uint16(0), v)
+}
+
+func Test_WriteNetUint16At(t *testing.T) {
+	b := New(nil)
+	err := b.WriteNetUint16At(0x1f2f, 1)
+	assert.Nil(t, err)
+
+	b.Advance(1)
+	tmp, err := b.ReadNetUint16()
+	assert.Nil(t, err)
+	assert.Equal(t, uint16(0x1f2f), tmp)
+}
+
+func Test_ReadNetUint32NoData(t *testing.T) {
+	b := New(nil)
+	v, err := b.ReadNetUint32()
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Equal(t, uint32(0), v)
+}
+
+func Test_ReadNetUint32Failed(t *testing.T) {
+	b := New(nil)
+	b.SetError(ErrTest)
+	v, err := b.ReadNetUint32()
+	assert.Equal(t, ErrTest, err)
+	assert.Equal(t, uint32(0), v)
+}
+
+func Test_ReadNetUint32Data(t *testing.T) {
+	b := New([]byte{0xf1, 0xf2, 0xf3, 0xf4})
+	v, err := b.ReadNetUint32()
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(0xf1f2f3f4), v)
+}
+
+func Test_ReadNetUint32AtFailed(t *testing.T) {
+	b := New(nil)
+	b.SetError(ErrTest)
+	v, err := b.ReadNetUint32At(4)
+	assert.Equal(t, ErrTest, err)
+	assert.Equal(t, uint32(0), v)
+}
+
+func Test_ReadNetUint32AtInRange(t *testing.T) {
+	b := New([]byte{0xf1, 0xf2, 0xf3, 0xf4, 0xf5})
+	v, err := b.ReadNetUint32At(1)
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(0xf2f3f4f5), v)
+}
+
+func Test_ReadNetUint32AtOutOfRange(t *testing.T) {
+	b := New([]byte{0xf1, 0xf2, 0xf3})
+	v, err := b.ReadNetUint32At(2)
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Equal(t, uint32(0), v)
+}
+
+func Test_WriteNetUint32At(t *testing.T) {
+	b := New(nil)
+	err := b.WriteNetUint32At(0x1f2f3f4f, 1)
+	assert.Nil(t, err)
+
+	b.Advance(1)
+	tmp, err := b.ReadNetUint32()
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(0x1f2f3f4f), tmp)
+}
+
+func Test_ReadNetUint64NoData(t *testing.T) {
+	b := New(nil)
+	v, err := b.ReadNetUint64()
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Equal(t, uint64(0), v)
+}
+
+func Test_ReadNetUint64Failed(t *testing.T) {
+	b := New(nil)
+	b.SetError(ErrTest)
+	v, err := b.ReadNetUint64()
+	assert.Equal(t, ErrTest, err)
+	assert.Equal(t, uint64(0), v)
+}
+
+func Test_ReadNetUint64Data(t *testing.T) {
+	b := New([]byte{
+		0xf0, 0xf1, 0xf2, 0xf3, 0xf4,
+		0xf5, 0xf6, 0xf7, 0xf8, 0xf9,
+		0xfa, 0xfb, 0xfc, 0xfd, 0xfe,
+	})
+	v, err := b.ReadNetUint64()
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(0xf0f1f2f3f4f5f6f7), v)
+}
+
+func Test_ReadNetUint64AtFailed(t *testing.T) {
+	b := New(nil)
+	b.SetError(ErrTest)
+	v, err := b.ReadNetUint64At(4)
+	assert.Equal(t, ErrTest, err)
+	assert.Equal(t, uint64(0), v)
+}
+
+func Test_ReadNetUint64AtInRange(t *testing.T) {
+	b := New([]byte{
+		0xf0, 0xf1, 0xf2, 0xf3, 0xf4,
+		0xf5, 0xf6, 0xf7, 0xf8, 0xf9,
+		0xfa, 0xfb, 0xfc, 0xfd, 0xfe,
+	})
+	v, err := b.ReadNetUint64At(1)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(0xf1f2f3f4f5f6f7f8), v)
+}
+
+func Test_ReadNetUint64AtOutOfRange(t *testing.T) {
+	b := New([]byte{0xf1, 0xf2, 0xf3})
+	v, err := b.ReadNetUint64At(2)
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Equal(t, uint64(0), v)
+}
+
+func Test_WriteNetUint64At(t *testing.T) {
+	b := New(nil)
+	err := b.WriteNetUint64At(0x1f2f3f4f5f6f7f8f, 1)
+	assert.Nil(t, err)
+
+	b.Advance(1)
+	tmp, err := b.ReadNetUint64()
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(0x1f2f3f4f5f6f7f8f), tmp)
+}

--- a/common/streambuf/streambuf.go
+++ b/common/streambuf/streambuf.go
@@ -1,0 +1,337 @@
+// The streambuf module provides helpers for buffering multiple packet payloads
+// and some general parsing functions. All parsing functions are re-entrant,
+// that is if a parse function fails due do not having buffered enough bytes yet
+// (error value ErrNoMoreBytes) the parser can be called again after appending more
+// bytes to the buffer. Parsers potentially reading large amount of bytes might
+// remember the last position.
+// Additionally a Buffer can be marked as fixed. Fixed buffers to not support
+// adding new data, plus ErrNoMoreBytes will never be returned. Instead if a parser
+// decides it need more bytes ErrUnexpectedEOB will be returned.
+//
+// Error handling:
+// All functions that might fail, will return an error. The last error reported
+// will be stored with the buffer itself. Instead of checking every single error
+// one can use the Failed() and Err() methods to check if the buffer is still in a
+// valid state and all parsing was successfull.
+package streambuf
+
+import (
+	"github.com/elastic/libbeat/logp"
+
+	"bytes"
+	"errors"
+)
+
+// Error returned if Append or Write operation is not allowed due to the buffer
+// being fixed
+var ErrOperationNotAllowed = errors.New("Operation not allowed")
+
+var ErrOutOfRange = errors.New("Data access out of range")
+
+// Parse operation can not be continued. More bytes required. Only returned if
+// buffer is not fixed
+var ErrNoMoreBytes = errors.New("No more bytes")
+
+// Parse operation failed cause of buffer snapped short + buffer is fixed.
+var ErrUnexpectedEOB = errors.New("unexpected end of buffer")
+
+var ErrExpectedByteSequenceMismatch = errors.New("expected byte sequence did not match")
+
+// A Buffer is a variable sized buffer of bytes with Read, Write and simple
+// parsing methods. The zero value is an empty buffer ready for use.
+//
+// A Buffer can be marked as fixed. In this case no data can be appended to the
+// buffer anymore and parser/reader methods will fail with ErrUnexpectedEOB if they
+// would expect more bytes to come. Mark buffers fixed if some slice was separated
+// for further parsing first.
+type Buffer struct {
+	data  []byte
+	err   error
+	fixed bool
+
+	// Internal parser state offsets.
+	// Offset is the position a parse might continue to work at when called
+	// again (e.g. usefull for parsing tcp streams.). The mark is used to remember
+	// the position last parse operation ended at. The variable available is used
+	// for faster lookup
+	// Invariants:
+	//    (1) 0 <= mark <= offset
+	//    (2) 0 <= available <= len(data)
+	//    (3) available = len(data) - mark
+	mark, offset, available int
+}
+
+// Init initializes a zero buffer with some byte slice being retained by the
+// buffer. Usage of Init is optional as zero value Buffer is already in valid state.
+func (b *Buffer) Init(d []byte, fixed bool) {
+	b.data = d
+	b.available = len(d)
+	b.fixed = fixed
+}
+
+// New creates new extensible buffer from data slice being retained by the buffer.
+func New(data []byte) *Buffer {
+	return &Buffer{
+		data:      data,
+		fixed:     false,
+		available: len(data),
+	}
+}
+
+// NewFixed create new fixed buffer from data slice being retained by the buffer.
+func NewFixed(data []byte) *Buffer {
+	return &Buffer{
+		data:      data,
+		fixed:     true,
+		available: len(data),
+	}
+}
+
+// Snapshot creates a snapshot of buffers current state. Use in conjunction with
+// Restore to get simple backtracking support. Between Snapshot and Restore the
+// Reset method MUST not be called, as restored buffer will be in invalid state
+// after.
+func (b *Buffer) Snapshot() *Buffer {
+	tmp := *b
+	return &tmp
+}
+
+// Restore restores a buffers state. Use in conjunction with
+// Snapshot to get simple backtracking support. Between Snapshot and Restore the
+// Reset method MUST not be called, as restored buffer will be in invalid state
+// after.
+func (b *Buffer) Restore(snapshot *Buffer) {
+	b.err = snapshot.err
+	b.fixed = snapshot.fixed
+	b.mark = snapshot.mark
+	b.offset = snapshot.offset
+	b.available = snapshot.available
+}
+
+func (b *Buffer) doAppend(data []byte, retainable bool) error {
+	if b.fixed {
+		return b.SetError(ErrOperationNotAllowed)
+	}
+	if b.err != nil && b.err != ErrNoMoreBytes {
+		return b.err
+	}
+
+	if len(b.data) == 0 {
+		if retainable {
+			b.data = data
+		} else {
+			b.data = make([]byte, len(data))
+			copy(b.data, data)
+		}
+	} else {
+		b.data = append(b.data, data...)
+	}
+	b.available += len(data)
+
+	// reset error status (continue parsing)
+	if b.err == ErrNoMoreBytes {
+		b.err = nil
+	}
+
+	return nil
+}
+
+// Append will append the given data to the buffer. If Buffer is fixed
+// ErrOperationNotAllowed will be returned.
+func (b *Buffer) Append(data []byte) error {
+	return b.doAppend(data, true)
+}
+
+// Fix marks a buffer as fixed. No more data can be added to the buffer and
+// parse operation might fail if they expect more bytes.
+func (b *Buffer) Fix() {
+	b.fixed = true
+}
+
+// Total returns the total number of bytes stored in the buffer
+func (b *Buffer) Total() int {
+	return len(b.data)
+}
+
+// Avail checks if count bytes are available for reading from the buffer.
+func (b *Buffer) Avail(count int) bool {
+	return count <= b.available
+}
+
+// Len returns the number of bytes of the unread portion.
+func (b *Buffer) Len() int {
+	return b.available
+}
+
+// LeftBehind returns the number of bytes a re-entrant but not yet finished
+// parser did already read.
+func (b *Buffer) LeftBehind() int {
+	return b.offset - b.mark
+}
+
+// BufferConsumed returns the number of bytes already consumed since last call to Reset.
+func (b *Buffer) BufferConsumed() int {
+	return b.mark
+}
+
+// Advance will advance the buffers read pointer by count bytes. Returns
+// ErrNoMoreBytes or ErrUnexpectedEOB if count bytes are not available.
+func (b *Buffer) Advance(count int) error {
+	if !b.Avail(count) {
+		return b.bufferEndError()
+	}
+	b.mark += count
+	b.offset = b.mark
+	b.available -= count
+	return nil
+}
+
+// Failed returns true if buffer is in failed state. If buffer is in failed
+// state, almost all buffer operations will fail
+func (b *Buffer) Failed() bool {
+	failed := b.err != nil
+	if failed {
+		logp.Debug("streambuf", "buf parser already failed with: %s", b.err)
+	}
+	return failed
+}
+
+// Returns the error value of the last failed operation.
+func (b *Buffer) Err() error {
+	return b.err
+}
+
+// Check if n bytes are addressable in the buffer offset at b.mark and
+// increases either the length or allocates bigger slice if necessary
+func (b *Buffer) ensureLen(n int) {
+	delta := n - b.available
+	if delta <= 0 {
+		// no additional space required:
+		return
+	}
+
+	// newly available bytes
+	b.available += delta
+
+	total := len(b.data) + delta
+	if total <= cap(b.data) {
+		// enough space in slice -> grow it
+		b.data = b.data[0:total]
+		return
+	}
+
+	tmp := make([]byte, total)
+	copy(tmp, b.data)
+	b.data = tmp
+}
+
+// return slice to write to starting at off + b.mark with given length.
+func (b *Buffer) sliceAt(off, len int) []byte {
+	off += b.mark
+	end := off + len
+	b.ensureLen(end - b.mark)
+	return b.data[off:end]
+}
+
+// Consume removes the first n bytes (special variant of Reset) from the
+// beginning of the buffer, if at least n bytes have already been processed.
+// Returns the byte slice of all bytes being removed from the buffer.
+// If total buffer is < n, ErrOutOfRange will be reported or ErrOutOfRange if
+// not enough bytes have been processed yet.
+func (b *Buffer) Consume(n int) ([]byte, error) {
+	if n > len(b.data) {
+		return nil, ErrOutOfRange
+	}
+
+	new_mark := b.mark - n
+	if new_mark < 0 {
+		return nil, ErrOutOfRange
+	}
+
+	old := b.data[:n]
+	b.data = b.data[n:]
+	b.mark = new_mark
+	b.offset -= n
+	b.available = len(b.data) - b.mark
+	return old, nil
+}
+
+// Reset remove all bytes already processed from the buffer. Use Reset after
+// processing message to limit amount of buffered data.
+func (b *Buffer) Reset() {
+	b.data = b.data[b.mark:]
+	b.offset -= b.mark
+	b.mark = 0
+	b.available = len(b.data)
+	b.err = nil
+}
+
+// BufferedBytes returns all buffered bytes since last reset.
+func (b *Buffer) BufferedBytes() []byte {
+	return b.data
+}
+
+// Bytes returns all bytes not yet processed. The read counters are not advanced
+// yet. For example use with fixed Buffer for simple lookahead.
+//
+// Note:
+// The read markers are not advanced. If rest of buffer should be
+// processed, call Advance immediately.
+func (b *Buffer) Bytes() []byte {
+	return b.data[b.mark:]
+}
+
+func (b *Buffer) bufferEndError() error {
+	if b.fixed {
+		return b.SetError(ErrUnexpectedEOB)
+	} else {
+		return b.SetError(ErrNoMoreBytes)
+	}
+}
+
+// SetError marks a buffer as failed. Append and parse operations will fail with
+// err. SetError returns err directly.
+func (b *Buffer) SetError(err error) error {
+	b.err = err
+	return err
+}
+
+// Collect tries to collect count bytes from the buffer and updates the read
+// pointers. If the buffer is in failed state or count bytes are not available
+// an error will be returned.
+func (b *Buffer) Collect(count int) ([]byte, error) {
+	if b.Failed() {
+		return nil, b.err
+	}
+
+	if !b.Avail(count) {
+		return nil, b.bufferEndError()
+	}
+
+	data := b.data[b.mark : b.mark+count]
+	b.Advance(count)
+	return data, nil
+}
+
+// CollectWithDelimiter collects count bytes and checks delim will immediately
+// follow the byte sequence. Returns count bytes without delim.
+// If delim is not matched ErrExpectedByteSequenceMismatch will be raised.
+func (b *Buffer) CollectWithSuffix(count int, delim []byte) ([]byte, error) {
+	total := count + len(delim)
+	if b.Failed() {
+		return nil, b.err
+	}
+
+	if !b.Avail(total) {
+		return nil, b.bufferEndError()
+	}
+
+	end := b.mark + count
+	if !bytes.HasPrefix(b.data[end:], delim) {
+		return nil, b.SetError(ErrExpectedByteSequenceMismatch)
+	}
+
+	data := b.data[b.mark : b.mark+count]
+	b.Advance(total)
+	return data, nil
+}

--- a/common/streambuf/streambuf_test.go
+++ b/common/streambuf/streambuf_test.go
@@ -1,0 +1,303 @@
+package streambuf
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var ErrMarkInvariant = errors.New("mark value not within limits")
+var ErrAvailableInvariant = errors.New("available value not within limits")
+var ErrSizesInvariant = errors.New("available and mark values not in sync")
+
+var ErrTest = errors.New("test")
+
+func checkInvariants(b *Buffer) error {
+	if !(0 <= b.mark && b.mark <= b.offset) {
+		return ErrMarkInvariant
+	}
+	if !(0 <= b.available && b.available <= len(b.data)) {
+		return ErrAvailableInvariant
+	}
+	if !(b.available == len(b.data)-b.mark) {
+		return ErrSizesInvariant
+	}
+
+	return nil
+}
+
+func (b *Buffer) checkInvariants(t *testing.T) {
+	assert.Nil(t, checkInvariants(b))
+}
+
+func Test_InvariantsOnNew(t *testing.T) {
+	var b1 Buffer
+	b1.checkInvariants(t)
+
+	var b2 Buffer
+	b2.Init([]byte("test"), false)
+	b2.checkInvariants(t)
+
+	New([]byte("test")).checkInvariants(t)
+
+	NewFixed([]byte("test")).checkInvariants(t)
+}
+
+func Test_ErrorHandling(t *testing.T) {
+	b := New(nil)
+	b.checkInvariants(t)
+
+	assert.False(t, b.Failed())
+	assert.Nil(t, b.Err())
+
+	err := b.SetError(ErrTest)
+	assert.Equal(t, ErrTest, err)
+	assert.True(t, b.Failed())
+	assert.Equal(t, ErrTest, b.Err())
+}
+
+func Test_SnapshotRestore(t *testing.T) {
+	b := NewFixed([]byte("test test"))
+	snapshot := b.Snapshot()
+
+	err := b.Advance(5)
+	assert.Equal(t, 5, b.BufferConsumed())
+	assert.Equal(t, 4, b.Len())
+	assert.Nil(t, err)
+	assert.False(t, b.Failed())
+
+	b.Restore(snapshot)
+	b.checkInvariants(t)
+	assert.Equal(t, 9, b.Len())
+	assert.Equal(t, 0, b.BufferConsumed())
+}
+
+func Test_SnapshotRestoreAfterErr(t *testing.T) {
+	b := NewFixed([]byte("test test"))
+	snapshot := b.Snapshot()
+
+	err := b.Advance(20)
+	assert.True(t, b.Failed())
+	assert.Error(t, err)
+	assert.Error(t, b.Err())
+
+	b.Restore(snapshot)
+	b.checkInvariants(t)
+	assert.False(t, b.Failed())
+	assert.Nil(t, b.Err())
+}
+
+func Test_AppendNil(t *testing.T) {
+	b := NewFixed(nil)
+	b.Append(nil)
+	b.checkInvariants(t)
+	assert.Equal(t, 0, b.Len())
+}
+
+func Test_AppendRetainsBuffer(t *testing.T) {
+	d := []byte("test")
+	b := New(nil)
+
+	b.Append(d)
+	d[0] = 'a'
+	x, _ := b.Collect(1)
+	b.checkInvariants(t)
+	assert.False(t, b.Failed())
+	assert.Equal(t, d[0], x[0])
+}
+
+func Test_AppendOnFixed(t *testing.T) {
+	b := NewFixed([]byte("abc"))
+
+	err := b.Append([]byte("def"))
+	assert.Equal(t, ErrOperationNotAllowed, err)
+	assert.True(t, b.Failed())
+	assert.Equal(t, err, b.Err())
+}
+
+func Test_AppendOnFixedLater(t *testing.T) {
+	b := New([]byte("abc"))
+
+	err := b.Append([]byte("def"))
+	assert.Nil(t, err)
+
+	b.Fix()
+	err = b.Append([]byte("def"))
+	b.checkInvariants(t)
+	assert.Equal(t, ErrOperationNotAllowed, err)
+	assert.True(t, b.Failed())
+	assert.Equal(t, err, b.Err())
+}
+
+func Test_AppendOnFailed(t *testing.T) {
+	b := New([]byte("abc"))
+	b.SetError(ErrTest)
+	err := b.Append([]byte("def"))
+	assert.Equal(t, ErrTest, err)
+}
+
+func Test_AppendAfterNoMoreBytes(t *testing.T) {
+	b := New([]byte("a"))
+
+	err := b.Advance(5)
+	assert.Equal(t, ErrNoMoreBytes, err)
+
+	err = b.Append([]byte(" test"))
+	assert.Nil(t, err)
+	assert.False(t, b.Failed())
+}
+
+func Test_AvailAndLenConsiderRead(t *testing.T) {
+	b := New([]byte("test"))
+	b.Advance(3)
+	b.checkInvariants(t)
+	assert.Equal(t, 4, b.Total())
+	assert.Equal(t, 1, b.Len())
+	assert.Equal(t, 3, b.BufferConsumed())
+}
+
+func Test_AvailAndLenConsiderReset(t *testing.T) {
+	b := New([]byte("test"))
+	b.Advance(3)
+	b.Reset()
+	b.checkInvariants(t)
+	assert.Equal(t, 1, b.Total())
+	assert.Equal(t, 1, b.Len())
+	assert.Equal(t, 0, b.BufferConsumed())
+}
+
+func Test_ConsumeData(t *testing.T) {
+	b := New([]byte("test"))
+	b.Advance(3)
+	b.Consume(2)
+	b.checkInvariants(t)
+	assert.Equal(t, 2, b.Total())
+	assert.Equal(t, 1, b.Len())
+	assert.Equal(t, 1, b.BufferConsumed())
+}
+
+func Test_ConsumeFailed(t *testing.T) {
+	b := New([]byte("test"))
+	snapshot := b.Snapshot()
+
+	_, err := b.Consume(100)
+	assert.Equal(t, ErrOutOfRange, err)
+
+	b.Restore(snapshot)
+	assert.False(t, b.Failed())
+
+	_, err = b.Consume(3)
+	assert.Equal(t, ErrOutOfRange, err)
+}
+
+func Test_ByteGetUnconsumed(t *testing.T) {
+	b := New([]byte("test"))
+	b.Advance(3)
+	d := b.Bytes()
+
+	b.checkInvariants(t)
+	assert.Equal(t, 3, b.mark)
+	assert.Equal(t, 1, len(d))
+	assert.True(t, 't' == d[0])
+}
+
+func Test_ResetEmpty(t *testing.T) {
+	b := New(nil)
+	b.Reset()
+	b.checkInvariants(t)
+}
+
+func Test_ResetWhileParsing(t *testing.T) {
+	b := New([]byte("test"))
+	b.Advance(1)
+	b.offset += 2
+	b.checkInvariants(t)
+	assert.Equal(t, 3, b.offset)
+
+	b.Reset()
+	b.checkInvariants(t)
+	assert.Equal(t, 2, b.offset)
+}
+
+func Test_CollectData(t *testing.T) {
+	b := New([]byte("test"))
+	d, err := b.Collect(2)
+
+	b.checkInvariants(t)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("te"), d)
+}
+
+func Test_CollectFailed(t *testing.T) {
+	b := New([]byte("test"))
+	b.SetError(ErrTest)
+
+	d, err := b.Collect(2)
+	assert.Equal(t, ErrTest, err)
+	assert.Nil(t, d)
+}
+
+func Test_CollectNoData(t *testing.T) {
+	b := New(nil)
+
+	d, err := b.Collect(2)
+	assert.True(t, b.Failed())
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Nil(t, d)
+}
+
+func Test_CollectFixedNoData(t *testing.T) {
+	b := NewFixed(nil)
+
+	d, err := b.Collect(2)
+	assert.True(t, b.Failed())
+	assert.Equal(t, ErrUnexpectedEOB, err)
+	assert.Nil(t, d)
+}
+
+func Test_CollectWithSuffixData(t *testing.T) {
+	b := New([]byte("test\r\ntest"))
+
+	d, err := b.CollectWithSuffix(4, []byte("\r\n"))
+	b.checkInvariants(t)
+	assert.False(t, b.Failed())
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("test"), d)
+}
+
+func Test_CollectWithSuffixFail(t *testing.T) {
+	b := New([]byte("test\n\ntest"))
+
+	d, err := b.CollectWithSuffix(4, []byte("\r\n"))
+	assert.True(t, b.Failed())
+	assert.Nil(t, d)
+	assert.Equal(t, ErrExpectedByteSequenceMismatch, err)
+}
+
+func Test_CollectWithSuffixFailed(t *testing.T) {
+	b := New([]byte("test\r\ntest"))
+	b.SetError(ErrTest)
+
+	d, err := b.CollectWithSuffix(4, []byte("\r\n"))
+	assert.Equal(t, ErrTest, err)
+	assert.Nil(t, d)
+}
+
+func Test_CollectWithSuffixNoData(t *testing.T) {
+	b := New(nil)
+
+	d, err := b.CollectWithSuffix(4, []byte("\r\n"))
+	assert.True(t, b.Failed())
+	assert.Equal(t, ErrNoMoreBytes, err)
+	assert.Nil(t, d)
+}
+
+func Test_CollectWithSuffixFixedNoData(t *testing.T) {
+	b := NewFixed(nil)
+
+	d, err := b.CollectWithSuffix(4, []byte("\r\n"))
+	assert.True(t, b.Failed())
+	assert.Equal(t, ErrUnexpectedEOB, err)
+	assert.Nil(t, d)
+}


### PR DESCRIPTION
Move some helpers for memcached support from packetbeat to libbeat.

Please do not merge this pull request until tests have been add to these modules.

Contains:
- applayer: provides some structures with common fields used by application layer protocols + initialisation of common fields + setting common fields in MapStr for publishing

- streambuf: parse buffer for appending tcp/udp payloads to + some simple re-entrant helper routines for parsing a continues stream of data.