### PR TITLE
Use the beat name as default index in Elasticsearch

### DIFF
--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -30,7 +30,7 @@ type PublishedTopology struct {
 }
 
 // Initialize Elasticsearch as output
-func (out *ElasticsearchOutput) Init(config outputs.MothershipConfig, topology_expire int) error {
+func (out *ElasticsearchOutput) Init(beat string, config outputs.MothershipConfig, topology_expire int) error {
 
 	if len(config.Protocol) == 0 {
 		config.Protocol = "http"
@@ -56,7 +56,7 @@ func (out *ElasticsearchOutput) Init(config outputs.MothershipConfig, topology_e
 	if config.Index != "" {
 		out.Index = config.Index
 	} else {
-		out.Index = "packetbeat"
+		out.Index = beat
 	}
 
 	out.TopologyExpire = 15000

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -36,19 +36,20 @@ func createElasticsearchConnection(flush_interval int, bulk_size int) Elasticsea
 	}
 
 	var elasticsearchOutput ElasticsearchOutput
-	elasticsearchOutput.Init(outputs.MothershipConfig{
-		Enabled:        true,
-		Save_topology:  true,
-		Host:           elasticsearchAddr,
-		Port:           es_port,
-		Username:       "",
-		Password:       "",
-		Path:           "",
-		Index:          index,
-		Protocol:       "",
-		Flush_interval: &flush_interval,
-		Bulk_size:      &bulk_size,
-	}, 10)
+	elasticsearchOutput.Init("packetbeat",
+		outputs.MothershipConfig{
+			Enabled:        true,
+			Save_topology:  true,
+			Host:           elasticsearchAddr,
+			Port:           es_port,
+			Username:       "",
+			Password:       "",
+			Path:           "",
+			Index:          index,
+			Protocol:       "",
+			Flush_interval: &flush_interval,
+			Bulk_size:      &bulk_size,
+		}, 10)
 
 	return elasticsearchOutput
 }

--- a/outputs/fileout/file.go
+++ b/outputs/fileout/file.go
@@ -13,11 +13,11 @@ type FileOutput struct {
 	rotator logp.FileRotator
 }
 
-func (out *FileOutput) Init(config outputs.MothershipConfig, topology_expire int) error {
+func (out *FileOutput) Init(beat string, config outputs.MothershipConfig, topology_expire int) error {
 	out.rotator.Path = config.Path
 	out.rotator.Name = config.Filename
 	if out.rotator.Name == "" {
-		out.rotator.Name = "packetbeat"
+		out.rotator.Name = beat
 	}
 
 	rotateeverybytes := uint64(config.Rotate_every_kb) * 1024

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -33,7 +33,7 @@ type MothershipConfig struct {
 // Functions to be exported by a output plugin
 type OutputInterface interface {
 	// Initialize the output plugin
-	Init(config MothershipConfig, topology_expire int) error
+	Init(beat string, config MothershipConfig, topology_expire int) error
 
 	// Register the agent name and its IPs to the topology map
 	PublishIPs(name string, localAddrs []string) error

--- a/outputs/redis/redis.go
+++ b/outputs/redis/redis.go
@@ -46,7 +46,7 @@ type RedisQueueMsg struct {
 	msg   string
 }
 
-func (out *RedisOutput) Init(config outputs.MothershipConfig, topology_expire int) error {
+func (out *RedisOutput) Init(beat string, config outputs.MothershipConfig, topology_expire int) error {
 
 	out.Hostname = fmt.Sprintf("%s:%d", config.Host, config.Port)
 
@@ -71,7 +71,7 @@ func (out *RedisOutput) Init(config outputs.MothershipConfig, topology_expire in
 	if config.Index != "" {
 		out.Index = config.Index
 	} else {
-		out.Index = "packetbeat"
+		out.Index = beat
 	}
 
 	out.FlushInterval = 1000 * time.Millisecond

--- a/publisher/publish.go
+++ b/publisher/publish.go
@@ -219,7 +219,7 @@ func (publisher *PublisherType) PublishTopology(params ...string) error {
 	return nil
 }
 
-func (publisher *PublisherType) Init(outputs map[string]outputs.MothershipConfig, shipper ShipperConfig) error {
+func (publisher *PublisherType) Init(beat string, outputs map[string]outputs.MothershipConfig, shipper ShipperConfig) error {
 	var err error
 	publisher.IgnoreOutgoing = shipper.Ignore_outgoing
 
@@ -234,7 +234,7 @@ func (publisher *PublisherType) Init(outputs map[string]outputs.MothershipConfig
 		outputName := outputId.String()
 		output, exists := outputs[outputName]
 		if exists && output.Enabled && !publisher.disabled {
-			err := plugin.Init(output, shipper.Topology_expire)
+			err := plugin.Init(beat, output, shipper.Topology_expire)
 			if err != nil {
 				logp.Err("Fail to initialize %s plugin as output: %s", outputName, err)
 				return err


### PR DESCRIPTION
Pass the beat name to the publisher init function in order to be used as default
index if none is set in the configuration file.