### PR TITLE
Introduce MakeDebug

### DIFF
--- a/logp/log.go
+++ b/logp/log.go
@@ -37,7 +37,7 @@ type Logger struct {
 
 var _log Logger
 
-func Debug(selector string, format string, v ...interface{}) {
+func debugMessage(calldepth int, selector, format string, v ...interface{}) {
 	if _log.level >= LOG_DEBUG {
 		if !_log.debug_all_selectors {
 			selected := _log.selectors[selector]
@@ -46,14 +46,24 @@ func Debug(selector string, format string, v ...interface{}) {
 			}
 		}
 		if _log.toSyslog {
-			_log.syslog[LOG_INFO].Output(2, fmt.Sprintf(format, v...))
+			_log.syslog[LOG_INFO].Output(calldepth, fmt.Sprintf(format, v...))
 		}
 		if _log.toStderr {
-			_log.logger.Output(2, fmt.Sprintf("DBG  "+format, v...))
+			_log.logger.Output(calldepth, fmt.Sprintf("DBG  "+format, v...))
 		}
 		if _log.toFile {
 			_log.rotator.WriteLine([]byte(fmt.Sprintf("DBG  "+format, v...)))
 		}
+	}
+}
+
+func Debug(selector string, format string, v ...interface{}) {
+	debugMessage(3, selector, format, v...)
+}
+
+func MakeDebug(selector string) func(string, ...interface{}) {
+	return func(msg string, v ...interface{}) {
+		debugMessage(4, selector, msg, v...)
 	}
 }
 


### PR DESCRIPTION
Add MakeDebug to logp module. Use MakeDebug to create dedicated per module debug functions.

Instead of writing:

    logp.Debug("mymodule", "log message 1")
    ....
    logp.Debug("mymodule", "log message 2")

use MakeDebug to create on per module logging function still printing correct line numbers:

    var debug = logp.MakeDebug("mymodule")
    ....
    debug("log message 1")
    ....
    debug("log message 2")

