### PR TITLE
Fix handle signals.

### DIFF
--- a/beat/beat.go
+++ b/beat/beat.go
@@ -3,13 +3,14 @@ package beat
 import (
 	"flag"
 	"fmt"
+	"os"
+	"runtime"
+
 	"github.com/elastic/libbeat/cfgfile"
 	"github.com/elastic/libbeat/logp"
 	"github.com/elastic/libbeat/outputs"
 	"github.com/elastic/libbeat/publisher"
 	"github.com/elastic/libbeat/service"
-	"os"
-	"runtime"
 )
 
 // Beater interface that every beat must use
@@ -103,11 +104,12 @@ func (b *Beat) Run() {
 	}
 	service.BeforeRun()
 
+	// Callback is called if the processes is asked to stop
+	service.HandleSignals(b.BT.Stop)
+
 	// Run beater specific stuff
 	b.BT.Run(b)
 
-	// Function called in case of beater stop
-	service.HandleSignals(b.BT.Stop)
 	service.Cleanup()
 
 	logp.Debug("main", "Cleanup")

--- a/beat/beat.go
+++ b/beat/beat.go
@@ -104,7 +104,9 @@ func (b *Beat) Run() {
 	}
 	service.BeforeRun()
 
-	// Callback is called if the processes is asked to stop
+	// Callback is called if the processes is asked to stop.
+	// This needs to be called before the main loop is started so that
+	// it can register the signals that stop or query (on Windows) the loop.
 	service.HandleSignals(b.BT.Stop)
 
 	// Run beater specific stuff


### PR DESCRIPTION
It needs to be called before the Run function, otherwise it is
essentially never reached. This was especially a problem on Windows
were the service is checked via "signals" that is responsive, and
killed otherwise.