### PR TITLE
Exit after printing the version.

### DIFF
--- a/beat/beat.go
+++ b/beat/beat.go
@@ -65,7 +65,7 @@ func (beat *Beat) CommandLineSetup() {
 
 	if *printVersion {
 		fmt.Printf("%s version %s (%s)\n", beat.Name, beat.Version, runtime.GOARCH)
-		return
+		os.Exit(0)
 	}
 }
 


### PR DESCRIPTION
Returning is not enough, because the code flow will continue trying to
setup and start the Beat (which might or might not fail).