### PR TITLE
Environment Variables for service integration tests

### DIFF
--- a/outputs/elasticsearch/api_test.go
+++ b/outputs/elasticsearch/api_test.go
@@ -8,17 +8,33 @@ import (
 	"testing"
 )
 
-func GetTestingElasticsearch() *Elasticsearch {
-	var es_url string
+const ElasticsearchDefaultHost = "localhost"
+const ElasticsearchDefaultPort = "9200"
 
-	// read the Elasticsearch port from the ES_PORT env variable
+func GetEsPort() string {
 	port := os.Getenv("ES_PORT")
-	if len(port) > 0 {
-		es_url = "http://localhost:" + port
-	} else {
-		// empty variable
-		es_url = "http://localhost:9200"
+
+	if len(port) == 0 {
+		port = ElasticsearchDefaultPort
 	}
+	return port
+}
+
+// Returns
+func GetEsHost() string {
+
+	host := os.Getenv("ES_HOST")
+
+	if len(host) == 0 {
+		host = ElasticsearchDefaultHost
+	}
+
+	return host
+}
+
+func GetTestingElasticsearch() *Elasticsearch {
+
+	var es_url = "http://" + GetEsHost() + ":" + GetEsPort()
 
 	return NewElasticsearch([]string{es_url}, "", "")
 }

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -12,49 +12,37 @@ import (
 	"github.com/elastic/libbeat/outputs"
 )
 
-const elasticsearchAddr = "localhost"
-const elasticsearchPort = 9200
-
 func createElasticsearchConnection(flush_interval int, bulk_size int) ElasticsearchOutput {
 
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
 
-	var es_port int
-	var err error
+	esPort, err := strconv.Atoi(GetEsPort())
 
-	// read the Elasticsearch port from the ES_PORT env variable
-	port := os.Getenv("ES_PORT")
-	if len(port) > 0 {
-		es_port, err = strconv.Atoi(port)
-		if err != nil {
-			// error occurred, use the default
-			es_port = elasticsearchPort
-		}
-	} else {
-		// empty variable
-		es_port = elasticsearchPort
+	if err != nil {
+		logp.Err("Invalid port. Cannot be converted to in: %s", GetEsPort())
 	}
 
 	var elasticsearchOutput ElasticsearchOutput
-	elasticsearchOutput.Init("packetbeat",
-		outputs.MothershipConfig{
-			Enabled:        true,
-			Save_topology:  true,
-			Host:           elasticsearchAddr,
-			Port:           es_port,
-			Username:       "",
-			Password:       "",
-			Path:           "",
-			Index:          index,
-			Protocol:       "",
-			Flush_interval: &flush_interval,
-			Bulk_size:      &bulk_size,
-		}, 10)
+
+	elasticsearchOutput.Init("packetbeat", outputs.MothershipConfig{
+		Enabled:        true,
+		Save_topology:  true,
+		Host:           GetEsHost(),
+		Port:           esPort,
+		Username:       "",
+		Password:       "",
+		Path:           "",
+		Index:          index,
+		Protocol:       "",
+		Flush_interval: &flush_interval,
+		Bulk_size:      &bulk_size,
+	}, 10)
 
 	return elasticsearchOutput
 }
 
 func TestTopologyInES(t *testing.T) {
+
 	if testing.Short() {
 		t.Skip("Skipping topology tests in short mode, because they require Elasticsearch")
 	}

--- a/outputs/redis/redis_test.go
+++ b/outputs/redis/redis_test.go
@@ -1,11 +1,29 @@
 package redis
 
 import (
+	"os"
 	"testing"
 	"time"
 )
 
-const redisAddr = ":6379"
+const RedisDefaultHost = "localhost"
+const RedisDefaultPort = "6379"
+
+func GetRedisAddr() string {
+
+	port := os.Getenv("REDIS_PORT")
+	host := os.Getenv("REDIS_HOST")
+
+	if len(port) == 0 {
+		port = RedisDefaultPort
+	}
+
+	if len(host) == 0 {
+		host = RedisDefaultHost
+	}
+
+	return host + ":" + port
+}
 
 func TestTopologyInRedis(t *testing.T) {
 	if testing.Short() {
@@ -14,7 +32,7 @@ func TestTopologyInRedis(t *testing.T) {
 
 	var redisOutput1 = RedisOutput{
 		Index:          "packetbeat",
-		Hostname:       redisAddr,
+		Hostname:       GetRedisAddr(),
 		Password:       "",
 		DbTopology:     1,
 		Timeout:        time.Duration(5) * time.Second,
@@ -23,7 +41,7 @@ func TestTopologyInRedis(t *testing.T) {
 
 	var redisOutput2 = RedisOutput{
 		Index:          "packetbeat",
-		Hostname:       redisAddr,
+		Hostname:       GetRedisAddr(),
 		Password:       "",
 		DbTopology:     1,
 		Timeout:        time.Duration(5) * time.Second,
@@ -32,7 +50,7 @@ func TestTopologyInRedis(t *testing.T) {
 
 	var redisOutput3 = RedisOutput{
 		Index:          "packetbeat",
-		Hostname:       redisAddr,
+		Hostname:       GetRedisAddr(),
 		Password:       "",
 		DbTopology:     1,
 		Timeout:        time.Duration(5) * time.Second,


### PR DESCRIPTION
This changes allows it to set environment variables for the elasticsearch and redis service host and port. This makes it more flexbile to be integrated with docker or a service running on a remote host.

I split up https://github.com/elastic/libbeat/pull/34 as there are some open issue which needs more time. We should have this one in already so local testing gets easier. I will push the Docker setup in a second pull request so we can discuss there if we need it.