### PR TITLE
Environment to run clean test suite with one command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.4
+MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
+
+## Install go package dependencies
+RUN go get \
+	github.com/pierrre/gotestcover \
+	github.com/tools/godep \
+	github.com/tsg/goautotest \
+	golang.org/x/tools/cmd/cover \
+	golang.org/x/tools/cmd/vet
+
+WORKDIR /go/src/github.com/elastic/libbeat
+# Setup work environment
+RUN mkdir -p /go/src/github.com/elastic/libbeat
+
+COPY . /go/src/github.com/elastic/libbeat
+
+RUN make

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 GODEP=$(GOPATH)/bin/godep
 
 .PHONY: build
-build: 
+build:
 	go get github.com/tools/godep
-	#$(GODEP) go build
+	$(GODEP) go build ./...
 
 .PHONY: deps
 deps:
@@ -40,10 +40,34 @@ cover:
 	go get github.com/pierrre/gotestcover
 	GOPATH=$(shell $(GODEP) path):$(GOPATH) $(GOPATH)/bin/gotestcover -coverprofile=profile.cov -covermode=count github.com/elastic/libbeat/...
 	mkdir -p cover
-	$(GODEP)  go tool cover -html=profile.cov -o cover/coverage.html
+	$(GODEP) go tool cover -html=profile.cov -o cover/coverage.html
 
 .PHONY: clean
 clean:
 	make gofmt
 	-rm profile.cov
 	-rm -r cover
+
+
+# Builds the environment to test libbeat
+.PHONY: build-image
+build-image:
+	make clean
+	docker-compose build
+
+# Runs the environment so the redis and elasticsearch can also be used for local development
+# To use it for running the test, set ES_HOST and REDIS_HOST environment variable to the ip of your docker-machine.
+.PHONY: run-environment
+run-environment: build-image
+	docker-compose run -d
+
+# Runs the full test suite and puts out the result. This can be run on any docker-machine (local, remote)
+.PHONY: testsuite
+testsuite: build-image
+	docker-compose run libbeat make testlong
+	docker ps -a
+	# Copy coverage file back to host
+	mkdir -p cover
+	docker cp libbeat_libbeat_run_1:/go/src/github.com/elastic/libbeat/profile.cov $(shell pwd)/profile.cov
+	docker cp libbeat_libbeat_run_1:/go/src/github.com/elastic/libbeat/cover/coverage.html $(shell pwd)/cover/coverage.html
+	docker-compose stop

--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,17 @@ build-image:
 .PHONY: run-environment
 run-environment: build-image
 	docker-compose run -d
+	
+.PHONY: stop-environment
+stop-environment:
+	docker-compose stop
 
 # Runs the full test suite and puts out the result. This can be run on any docker-machine (local, remote)
 .PHONY: testsuite
 testsuite: build-image
 	docker-compose run libbeat make testlong
-	docker ps -a
 	# Copy coverage file back to host
 	mkdir -p cover
 	docker cp libbeat_libbeat_run_1:/go/src/github.com/elastic/libbeat/profile.cov $(shell pwd)/profile.cov
 	docker cp libbeat_libbeat_run_1:/go/src/github.com/elastic/libbeat/cover/coverage.html $(shell pwd)/cover/coverage.html
-	docker-compose stop
+	make stop-environment

--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,14 @@ build-image:
 
 # Runs the environment so the redis and elasticsearch can also be used for local development
 # To use it for running the test, set ES_HOST and REDIS_HOST environment variable to the ip of your docker-machine.
-.PHONY: run-environment
-run-environment: build-image
-	docker-compose run -d
+.PHONY: start-environment
+start-environment: build-image
+	docker-compose up -d
 	
 .PHONY: stop-environment
 stop-environment:
 	docker-compose stop
+	docker-compose rm -f
 
 # Runs the full test suite and puts out the result. This can be run on any docker-machine (local, remote)
 .PHONY: testsuite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+libbeat:
+  build: .
+  links:
+    - redis
+    - elasticsearch
+  environment:
+    - ES_HOST=elasticsearch
+    - ES_PORT=9200
+    - REDIS_HOST=redis
+    - REDIS_PORT=6379
+elasticsearch:
+  image: elasticsearch
+  ports:
+    - "9200:9200"
+redis:
+  image: redis
+  ports:
+    - "6379:6379"


### PR DESCRIPTION
The test suite of libbeat depends on redis and elasticsearch. The goal was that everyone can start to develop and test the full project with as few commands as possible. To simplify the full test suite I introduced docker-compose and Docker environment to setup and run the test suite with just one command (assuming docker is installed):

```
make testsuite
````

This command fetches the images, runs the images and all tests. I suggest that this should be the command that every contributor runs before he opens a pull request as it guarantees that all his changes work in a "standardised" environment. It makes it possible to run everything also on a remote docker-machine.

## Environment
The tests were refactored to fetch the hosts and ports from the environment variables. This was necessary for the dynamic docker environment. In addition, it allows to use the docker redis and elasticsearch image also for the local development. This can be done with the following commands:

```
export ES_HOST=IP_OF_YOUR_DOCKER_MACHINE
export REDIS_HOST=IP_OF_YOUR_DOCKER_MACHINE
make run-environment
```
Like this the local golang environment can be used but still all tests work without any setup of redis or elasticsearch.

The current setup is with Golang 1.4 and the latest release version of elasticsearch.