### PR TITLE
Refactor and test Read config option to support files input

### DIFF
--- a/beat/beat.go
+++ b/beat/beat.go
@@ -75,7 +75,7 @@ func (beat *Beat) CommandLineSetup() {
 // This is Output, Logging and Shipper config params
 func (b *Beat) LoadConfig() {
 
-	err := cfgfile.Read(&b.Config)
+	err := cfgfile.Read(&b.Config, "")
 
 	if err != nil {
 		logp.Debug("Log read error", "Error %v\n", err)

--- a/cfgfile/cfgfile.go
+++ b/cfgfile/cfgfile.go
@@ -17,13 +17,21 @@ func CmdLineFlags(flags *flag.FlagSet, name string) {
 	testConfig = flags.Bool("test", false, "Test configuration and exit.")
 }
 
-func Read(out interface{}) error {
-	filecontent, err := ioutil.ReadFile(*configfile)
+// Reads config from yaml file into the given interface structure.
+// In case the second param path is not set
+func Read(out interface{}, path string) error {
+
+	if path == "" {
+		path = *configfile
+	}
+
+	filecontent, err := ioutil.ReadFile(path)
+
 	if err != nil {
-		return fmt.Errorf("Fail to read %s: %v. Exiting.", *configfile, err)
+		return fmt.Errorf("Fail to read %s: %v. Exiting.", path, err)
 	}
 	if err = yaml.Unmarshal(filecontent, out); err != nil {
-		return fmt.Errorf("YAML config parsing failed on %s: %v. Exiting.", *configfile, err)
+		return fmt.Errorf("YAML config parsing failed on %s: %v. Exiting.", path, err)
 	}
 
 	return nil

--- a/cfgfile/cfgfile.go
+++ b/cfgfile/cfgfile.go
@@ -17,7 +17,7 @@ func CmdLineFlags(flags *flag.FlagSet, name string) {
 	testConfig = flags.Bool("test", false, "Test configuration and exit.")
 }
 
-// Reads config from yaml file into the given interface structure.
+// Read reads the configuration from a yaml file into the given interface structure.
 // In case path is not set this method reads from the default configuration file for the beat.
 func Read(out interface{}, path string) error {
 

--- a/cfgfile/cfgfile.go
+++ b/cfgfile/cfgfile.go
@@ -18,7 +18,7 @@ func CmdLineFlags(flags *flag.FlagSet, name string) {
 }
 
 // Reads config from yaml file into the given interface structure.
-// In case the second param path is not set
+// In case path is not set this method reads from the default configuration file for the beat.
 func Read(out interface{}, path string) error {
 
 	if path == "" {
@@ -28,7 +28,7 @@ func Read(out interface{}, path string) error {
 	filecontent, err := ioutil.ReadFile(path)
 
 	if err != nil {
-		return fmt.Errorf("Fail to read %s: %v. Exiting.", path, err)
+		return fmt.Errorf("Failed to read %s: %v. Exiting.", path, err)
 	}
 	if err = yaml.Unmarshal(filecontent, out); err != nil {
 		return fmt.Errorf("YAML config parsing failed on %s: %v. Exiting.", path, err)

--- a/cfgfile/cfgfile_test.go
+++ b/cfgfile/cfgfile_test.go
@@ -1,0 +1,39 @@
+package cfgfile
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestConfig struct {
+	Server ElasticsearchConfig
+}
+
+type ElasticsearchConfig struct {
+	Elasticsearch Connection
+}
+
+type Connection struct {
+	Port int
+	Host string
+}
+
+func TestRead(t *testing.T) {
+	absPath, err := filepath.Abs("../tests/files/")
+
+	assert.NotNil(t, absPath)
+	assert.Nil(t, err)
+
+	config := &TestConfig{}
+
+	err = Read(config, absPath+"/config.yml")
+	assert.Nil(t, err)
+
+	// Access config
+	assert.Equal(t, "localhost", config.Server.Elasticsearch.Host)
+
+	// Chat that it is integer
+	assert.Equal(t, 9200, config.Server.Elasticsearch.Port)
+}

--- a/docs/newbeat.asciidoc
+++ b/docs/newbeat.asciidoc
@@ -143,7 +143,7 @@ With these structures defined, the `Config` function looks like this:
 ----------------------------------------------------------------------
 func (tb *Topbeat) Config(b *beat.Beat) error {
 
-	err := cfgfile.Read(&tb.TbConfig) <1>
+	err := cfgfile.Read(&tb.TbConfig, "") <1>
 	if err != nil {
 		logp.Err("Error reading configuration file: %v", err)
 		return err

--- a/tests/files/config.yml
+++ b/tests/files/config.yml
@@ -1,0 +1,4 @@
+server:
+  elasticsearch:
+    port: 9200
+    host: "localhost"

--- a/tests/files/config.yml
+++ b/tests/files/config.yml
@@ -1,4 +1,4 @@
 server:
   elasticsearch:
     port: 9200
-    host: "localhost"
+    host: localhost


### PR DESCRIPTION
Filebeat requires multiple config files to be read. The current config read implementation picked the path to read directly from the command line input. Now the path is put in through a parameter. Some tests were added to verify the changes.