### PR TITLE
Make all command line flags use the global flag Flagset

### DIFF
--- a/beat/beat.go
+++ b/beat/beat.go
@@ -27,7 +27,6 @@ type Beater interface {
 type Beat struct {
 	Name    string
 	Version string
-	CmdLine *flag.FlagSet
 	Config  *BeatConfig
 	BT      Beater
 	Events  chan common.MapStr
@@ -40,6 +39,12 @@ type BeatConfig struct {
 	Shipper publisher.ShipperConfig
 }
 
+var printVersion *bool
+
+func init() {
+	printVersion = flag.Bool("version", false, "Print version and exit")
+}
+
 // Initiates a new beat object
 func NewBeat(name string, version string, bt Beater) *Beat {
 	b := Beat{
@@ -48,7 +53,6 @@ func NewBeat(name string, version string, bt Beater) *Beat {
 		BT:      bt,
 	}
 
-	b.CmdLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	return &b
 }
 
@@ -56,14 +60,7 @@ func NewBeat(name string, version string, bt Beater) *Beat {
 // To set additional cmd line args use the beat.CmdLine type before calling the function
 func (beat *Beat) CommandLineSetup() {
 
-	cfgfile.CmdLineFlags(beat.CmdLine, beat.Name)
-	logp.CmdLineFlags(beat.CmdLine)
-	service.CmdLineFlags(beat.CmdLine)
-	publisher.CmdLineFlags(beat.CmdLine)
-
-	printVersion := beat.CmdLine.Bool("version", false, "Print version and exit")
-
-	beat.CmdLine.Parse(os.Args[1:])
+	flag.Parse()
 
 	if *printVersion {
 		fmt.Printf("%s version %s (%s)\n", beat.Name, beat.Version, runtime.GOARCH)

--- a/cfgfile/cfgfile.go
+++ b/cfgfile/cfgfile.go
@@ -12,9 +12,10 @@ import (
 var configfile *string
 var testConfig *bool
 
-func CmdLineFlags(flags *flag.FlagSet, name string) {
-	configfile = flags.String("c", fmt.Sprintf("/etc/%s/%s.yml", name, name), "Configuration file")
-	testConfig = flags.Bool("test", false, "Test configuration and exit.")
+func init() {
+	// The default config cannot include the beat name as it is not initialised when this function is called
+	configfile = flag.String("c", "/etc/beat/beat.yml", "Configuration file")
+	testConfig = flag.Bool("test", false, "Test configuration and exit.")
 }
 
 // Read reads the configuration from a yaml file into the given interface structure.

--- a/logp/logp.go
+++ b/logp/logp.go
@@ -21,6 +21,13 @@ type Logging struct {
 	To_files  *bool
 }
 
+func init() {
+	// Adds logging specific flags: -v, -e and -d.
+	verbose = flag.Bool("v", false, "Log at INFO level")
+	toStderr = flag.Bool("e", false, "Output to stdout and disable syslog/file output")
+	debugSelectorsStr = flag.String("d", "", "Enable certain debug selectors")
+}
+
 // Init combines the configuration from config with the command line
 // flags to initialize the Logging systems. After calling this function,
 // standard output is always enabled. You can make it respect the command
@@ -103,12 +110,4 @@ func SetStderr() {
 		Info("Startup successful, disable stdout logging")
 		SetToStderr(false, "")
 	}
-}
-
-// Adds logging specific flags to the flag set. The taken flags are
-// -v, -e and -d.
-func CmdLineFlags(flags *flag.FlagSet) {
-	verbose = flags.Bool("v", false, "Log at INFO level")
-	toStderr = flags.Bool("e", false, "Output to stdout and disable syslog/file output")
-	debugSelectorsStr = flags.String("d", "", "Enable certain debug selectors")
 }

--- a/publisher/publish.go
+++ b/publisher/publish.go
@@ -53,8 +53,8 @@ type Topology struct {
 	Ip   string `json:"ip"`
 }
 
-func CmdLineFlags(flags *flag.FlagSet) {
-	publishDisabled = flags.Bool("N", false, "Disable actual publishing for testing")
+func init() {
+	publishDisabled = flag.Bool("N", false, "Disable actual publishing for testing")
 }
 
 func PrintPublishEvent(event common.MapStr) {

--- a/service/service.go
+++ b/service/service.go
@@ -35,9 +35,9 @@ func HandleSignals(stopFunction func()) {
 // cmdline flags
 var memprofile, cpuprofile *string
 
-func CmdLineFlags(flags *flag.FlagSet) {
-	memprofile = flags.String("memprofile", "", "Write memory profile to this file")
-	cpuprofile = flags.String("cpuprofile", "", "Write cpu profile to file")
+func init() {
+	memprofile = flag.String("memprofile", "", "Write memory profile to this file")
+	cpuprofile = flag.String("cpuprofile", "", "Write cpu profile to file")
 }
 
 func WithMemProfile() bool {


### PR DESCRIPTION
The global flag object is used for the flag options as otherwise the flags are not discovered by the integration tests. 

This means packetbeat and topbeat also have to be updated. Pull requests are here:
* https://github.com/elastic/packetbeat/pull/237
* https://github.com/elastic/topbeat/pull/32