### PR TITLE
On errors reading the configuration file, exit immediately

### DIFF
--- a/beat/beat.go
+++ b/beat/beat.go
@@ -75,12 +75,13 @@ func (b *Beat) LoadConfig() {
 	err := cfgfile.Read(&b.Config, "")
 
 	if err != nil {
-		logp.Debug("Log read error", "Error %v\n", err)
+		fmt.Printf("%v\n", err)
+		os.Exit(1)
 	}
 
 	logp.Init(b.Name, &b.Config.Logging)
 
-	logp.Debug("main", "Initializing output plugins")
+	logp.Debug("beat", "Initializing output plugins")
 
 	if err := publisher.Publisher.Init(b.Name, b.Config.Output, b.Config.Shipper); err != nil {
 		logp.Critical(err.Error())
@@ -89,7 +90,7 @@ func (b *Beat) LoadConfig() {
 
 	b.Events = publisher.Publisher.Queue
 
-	logp.Debug(b.Name, "Init %s", b.Name)
+	logp.Debug("beat", "Init %s", b.Name)
 }
 
 // internal libbeat function that calls beater Run method
@@ -115,7 +116,7 @@ func (b *Beat) Run() {
 
 	service.Cleanup()
 
-	logp.Debug("main", "Cleanup")
+	logp.Debug("beat", "Cleanup")
 
 	// Call beater cleanup function
 	b.BT.Cleanup(b)


### PR DESCRIPTION
Printing is done directly with fmt.Println because the logging system
is not yet initialized there.

Also, changed some debug messages to use "beat" as the module, because
"main" is no longer accurate after the code was moved.

Should fix #58.