### PR TITLE
Feature/transactional publisher

### DIFF
--- a/beat/beat.go
+++ b/beat/beat.go
@@ -28,7 +28,7 @@ type Beat struct {
 	Version string
 	Config  *BeatConfig
 	BT      Beater
-	Events  publisher.EventPublisher
+	Events  publisher.Client
 }
 
 // Basic configuration of every beat

--- a/logp/log.go
+++ b/logp/log.go
@@ -63,7 +63,7 @@ func Debug(selector string, format string, v ...interface{}) {
 
 func MakeDebug(selector string) func(string, ...interface{}) {
 	return func(msg string, v ...interface{}) {
-		debugMessage(4, selector, msg, v...)
+		debugMessage(3, selector, msg, v...)
 	}
 }
 

--- a/outputs/elasticsearch/api.go
+++ b/outputs/elasticsearch/api.go
@@ -59,7 +59,7 @@ const (
 func NewElasticsearch(urls []string, username string, password string) *Elasticsearch {
 
 	var connection_pool ConnectionPool
-	connection_pool.SetConnections(urls, username, password)
+	_ = connection_pool.SetConnections(urls, username, password) // never errors
 
 	es := Elasticsearch{
 		connectionPool: connection_pool,
@@ -175,7 +175,7 @@ func (es *Elasticsearch) PerformRequest(conn *Connection, req *http.Request) ([]
 		return nil, do_retry, fmt.Errorf("%v", resp.Status)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	obj, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		es.connectionPool.MarkDead(conn)

--- a/outputs/elasticsearch/api.go
+++ b/outputs/elasticsearch/api.go
@@ -22,7 +22,7 @@ type QueryResult struct {
 	Ok      bool            `json:"ok"`
 	Index   string          `json:"_index"`
 	Type    string          `json:"_type"`
-	Id      string          `json:"_id"`
+	ID      string          `json:"_id"`
 	Source  json.RawMessage `json:"_source"`
 	Version int             `json:"_version"`
 	Found   bool            `json:"found"`
@@ -52,26 +52,26 @@ func (r QueryResult) String() string {
 }
 
 const (
-	default_max_retries = 3
+	defaultMaxRetries = 3
 )
 
-// Create a connection to Elasticsearch
+// NewElasticsearch creates a connection to Elasticsearch.
 func NewElasticsearch(urls []string, username string, password string) *Elasticsearch {
 
-	var connection_pool ConnectionPool
-	_ = connection_pool.SetConnections(urls, username, password) // never errors
+	var pool ConnectionPool
+	_ = pool.SetConnections(urls, username, password) // never errors
 
 	es := Elasticsearch{
-		connectionPool: connection_pool,
+		connectionPool: pool,
 		client:         &http.Client{},
-		MaxRetries:     default_max_retries,
+		MaxRetries:     defaultMaxRetries,
 	}
 	return &es
 }
 
 // Encode parameters in url
-func UrlEncode(params map[string]string) string {
-	var values url.Values = url.Values{}
+func urlEncode(params map[string]string) string {
+	values := url.Values{}
 
 	for key, val := range params {
 		values.Add(key, string(val))
@@ -79,15 +79,15 @@ func UrlEncode(params map[string]string) string {
 	return values.Encode()
 }
 
-// Create path out of index, doc_type and id that is used for querying Elasticsearch
-func MakePath(index string, doc_type string, id string) (string, error) {
+// Create path out of index, docType and id that is used for querying Elasticsearch
+func makePath(index string, docType string, id string) (string, error) {
 
 	var path string
-	if len(doc_type) > 0 {
+	if len(docType) > 0 {
 		if len(id) > 0 {
-			path = fmt.Sprintf("/%s/%s/%s", index, doc_type, id)
+			path = fmt.Sprintf("/%s/%s/%s", index, docType, id)
 		} else {
-			path = fmt.Sprintf("/%s/%s", index, doc_type)
+			path = fmt.Sprintf("/%s/%s", index, docType)
 		}
 	} else {
 		if len(id) > 0 {
@@ -103,7 +103,7 @@ func MakePath(index string, doc_type string, id string) (string, error) {
 	return path, nil
 }
 
-func ReadQueryResult(obj []byte) (*QueryResult, error) {
+func readQueryResult(obj []byte) (*QueryResult, error) {
 
 	var result QueryResult
 	if obj == nil {
@@ -116,7 +116,7 @@ func ReadQueryResult(obj []byte) (*QueryResult, error) {
 	return &result, err
 }
 
-func ReadSearchResult(obj []byte) (*SearchResults, error) {
+func readSearchResult(obj []byte) (*SearchResults, error) {
 
 	var result SearchResults
 	if obj == nil {
@@ -129,8 +129,8 @@ func ReadSearchResult(obj []byte) (*SearchResults, error) {
 	return &result, err
 }
 
-func (es *Elasticsearch) SetMaxRetries(max_retries int) {
-	es.MaxRetries = max_retries
+func (es *Elasticsearch) SetMaxRetries(maxRetries int) {
+	es.MaxRetries = maxRetries
 }
 
 func isConnTimeout(err error) bool {
@@ -145,7 +145,7 @@ func isConnRefused(err error) bool {
 // Mark the Elasticsearch node as dead for a period of time in the case the http request fails with Connection
 // Timeout, Connection Refused or returns one of the 503,504 Error Replies.
 // It returns the response, if it should retry sending the request and the error
-func (es *Elasticsearch) PerformRequest(conn *Connection, req *http.Request) ([]byte, bool, error) {
+func (es *Elasticsearch) performRequest(conn *Connection, req *http.Request) ([]byte, bool, error) {
 
 	req.Header.Add("Accept", "application/json")
 	if conn.Username != "" || conn.Password != "" {
@@ -155,24 +155,24 @@ func (es *Elasticsearch) PerformRequest(conn *Connection, req *http.Request) ([]
 	resp, err := es.client.Do(req)
 	if err != nil {
 		// request fails
-		do_retry := false
+		doRetry := false
 		if isConnTimeout(err) || isConnRefused(err) {
 			es.connectionPool.MarkDead(conn)
-			do_retry = true
+			doRetry = true
 		}
-		return nil, do_retry, fmt.Errorf("Sending the request fails: %s", err)
+		return nil, doRetry, fmt.Errorf("Sending the request fails: %s", err)
 	}
 
 	if resp.StatusCode > 299 {
 		// request fails
-		do_retry := false
+		doRetry := false
 		if resp.StatusCode == http.StatusServiceUnavailable ||
 			resp.StatusCode == http.StatusGatewayTimeout {
 			// status code in {503, 504}
 			es.connectionPool.MarkDead(conn)
-			do_retry = true
+			doRetry = true
 		}
-		return nil, do_retry, fmt.Errorf("%v", resp.Status)
+		return nil, doRetry, fmt.Errorf("%v", resp.Status)
 	}
 
 	defer func() { _ = resp.Body.Close() }()
@@ -189,9 +189,9 @@ func (es *Elasticsearch) PerformRequest(conn *Connection, req *http.Request) ([]
 
 }
 
-// Create an HTTP request and send it to Elasticsearch. The request is retransmitted max_retries
+// Create an HTTP request and send it to Elasticsearch. The request is retransmitted maxRetries
 // before returning an error.
-func (es *Elasticsearch) Request(method string, path string,
+func (es *Elasticsearch) request(method string, path string,
 	params map[string]string, body interface{}) ([]byte, error) {
 
 	var errors []error
@@ -199,11 +199,11 @@ func (es *Elasticsearch) Request(method string, path string,
 	for attempt := 0; attempt < es.MaxRetries; attempt++ {
 
 		conn := es.connectionPool.GetConnection()
-		logp.Debug("elasticsearch", "Use connection %s", conn.Url)
+		logp.Debug("elasticsearch", "Use connection %s", conn.URL)
 
-		url := conn.Url + path
+		url := conn.URL + path
 		if len(params) > 0 {
-			url = url + "?" + UrlEncode(params)
+			url = url + "?" + urlEncode(params)
 		}
 
 		logp.Debug("elasticsearch", "%s %s %s", method, url, body)
@@ -223,7 +223,7 @@ func (es *Elasticsearch) Request(method string, path string,
 			return nil, fmt.Errorf("NewRequest fails: %s", err)
 		}
 
-		resp, retry, err := es.PerformRequest(conn, req)
+		resp, retry, err := es.performRequest(conn, req)
 		if retry == true {
 			// retry
 			if err != nil {
@@ -247,12 +247,12 @@ func (es *Elasticsearch) Request(method string, path string,
 // searchable. In case id is empty, a new id is created over a HTTP POST request.
 // Otherwise, a HTTP PUT request is issued.
 // Implements: http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html
-func (es *Elasticsearch) Index(index string, doc_type string, id string,
+func (es *Elasticsearch) Index(index string, docType string, id string,
 	params map[string]string, body interface{}) (*QueryResult, error) {
 
 	var method string
 
-	path, err := MakePath(index, doc_type, id)
+	path, err := makePath(index, docType, id)
 	if err != nil {
 		return nil, fmt.Errorf("MakePath fails: %s", err)
 	}
@@ -261,76 +261,76 @@ func (es *Elasticsearch) Index(index string, doc_type string, id string,
 	} else {
 		method = "PUT"
 	}
-	resp, err := es.Request(method, path, params, body)
+	resp, err := es.request(method, path, params, body)
 	if err != nil {
 		return nil, err
 	}
-	return ReadQueryResult(resp)
+	return readQueryResult(resp)
 }
 
 // Refresh an index. Call this after doing inserts or creating/deleting
 // indexes in unit tests.
 func (es *Elasticsearch) Refresh(index string) (*QueryResult, error) {
-	path, err := MakePath(index, "", "_refresh")
+	path, err := makePath(index, "", "_refresh")
 	if err != nil {
 		return nil, err
 	}
-	resp, err := es.Request("POST", path, nil, nil)
+	resp, err := es.request("POST", path, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return ReadQueryResult(resp)
+	return readQueryResult(resp)
 }
 
-// Creates a new index, optionally with settings and mappings passed in
+// CreateIndex creates a new index, optionally with settings and mappings passed in
 // the body.
 // Implements: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html
 //
 func (es *Elasticsearch) CreateIndex(index string, body interface{}) (*QueryResult, error) {
 
-	path, err := MakePath(index, "", "")
+	path, err := makePath(index, "", "")
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := es.Request("PUT", path, nil, body)
+	resp, err := es.request("PUT", path, nil, body)
 	if err != nil {
 		return nil, err
 	}
 
-	return ReadQueryResult(resp)
+	return readQueryResult(resp)
 }
 
-// Deletes a typed JSON document from a specific index based on its id.
+// Delete deletes a typed JSON document from a specific index based on its id.
 // Implements: http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html
-func (es *Elasticsearch) Delete(index string, doc_type string, id string, params map[string]string) (*QueryResult, error) {
+func (es *Elasticsearch) Delete(index string, docType string, id string, params map[string]string) (*QueryResult, error) {
 
-	path, err := MakePath(index, doc_type, id)
+	path, err := makePath(index, docType, id)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := es.Request("DELETE", path, params, nil)
+	resp, err := es.request("DELETE", path, params, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return ReadQueryResult(resp)
+	return readQueryResult(resp)
 }
 
 // A search request can be executed purely using a URI by providing request parameters.
 // Implements: http://www.elastic.co/guide/en/elasticsearch/reference/current/search-uri-request.html
-func (es *Elasticsearch) SearchUri(index string, doc_type string, params map[string]string) (*SearchResults, error) {
+func (es *Elasticsearch) searchURI(index string, docType string, params map[string]string) (*SearchResults, error) {
 
-	path, err := MakePath(index, doc_type, "_search")
+	path, err := makePath(index, docType, "_search")
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := es.Request("GET", path, params, nil)
+	resp, err := es.request("GET", path, params, nil)
 	if err != nil {
 		return nil, err
 	}
-	return ReadSearchResult(resp)
+	return readSearchResult(resp)
 }

--- a/outputs/elasticsearch/api_mock_test.go
+++ b/outputs/elasticsearch/api_mock_test.go
@@ -38,9 +38,9 @@ func TestOneHostSuccessResp(t *testing.T) {
 		"post_date": "2009-11-15T14:12:12",
 		"message":   "trying out",
 	}
-	expected_resp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "test", Id: "1", Version: 1, Created: true})
+	expectedResp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "test", ID: "1", Version: 1, Created: true})
 
-	server := ElasticsearchMock(200, expected_resp)
+	server := ElasticsearchMock(200, expectedResp)
 
 	es := NewElasticsearch([]string{server.URL}, "", "")
 
@@ -128,10 +128,10 @@ func TestMultipleHosts(t *testing.T) {
 		"post_date": "2009-11-15T14:12:12",
 		"message":   "trying out",
 	}
-	expected_resp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "test", Id: "1", Version: 1, Created: true})
+	expectedResp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "test", ID: "1", Version: 1, Created: true})
 
 	server1 := ElasticsearchMock(503, []byte("Something went wrong"))
-	server2 := ElasticsearchMock(200, expected_resp)
+	server2 := ElasticsearchMock(200, expectedResp)
 
 	logp.Debug("elasticsearch", "%s, %s", server1.URL, server2.URL)
 	es := NewElasticsearch([]string{server1.URL, server2.URL}, "", "")

--- a/outputs/elasticsearch/api_test.go
+++ b/outputs/elasticsearch/api_test.go
@@ -2,10 +2,11 @@ package elasticsearch
 
 import (
 	"fmt"
-	"github.com/elastic/libbeat/logp"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/elastic/libbeat/logp"
+	"github.com/stretchr/testify/assert"
 )
 
 const ElasticsearchDefaultHost = "localhost"
@@ -34,9 +35,9 @@ func GetEsHost() string {
 
 func GetTestingElasticsearch() *Elasticsearch {
 
-	var es_url = "http://" + GetEsHost() + ":" + GetEsPort()
+	var address = "http://" + GetEsHost() + ":" + GetEsPort()
 
-	return NewElasticsearch([]string{es_url}, "", "")
+	return NewElasticsearch([]string{address}, "", "")
 }
 
 func GetValidQueryResult() QueryResult {
@@ -44,7 +45,7 @@ func GetValidQueryResult() QueryResult {
 		Ok:    true,
 		Index: "testIndex",
 		Type:  "testType",
-		Id:    "12",
+		ID:    "12",
 		Source: []byte(`{
 			"ok": true,
 			"_type":"testType",
@@ -93,7 +94,7 @@ func TestUrlEncode(t *testing.T) {
 	params := map[string]string{
 		"q": "agent:appserver1",
 	}
-	url := UrlEncode(params)
+	url := urlEncode(params)
 
 	if url != "q=agent%3Aappserver1" {
 		t.Errorf("Fail to encode params: %s", url)
@@ -104,7 +105,7 @@ func TestUrlEncode(t *testing.T) {
 		"husband": "joe",
 	}
 
-	url = UrlEncode(params)
+	url = urlEncode(params)
 
 	if url != "husband=joe&wife=sarah" {
 		t.Errorf("Fail to encode params: %s", url)
@@ -112,7 +113,7 @@ func TestUrlEncode(t *testing.T) {
 }
 
 func TestMakePath(t *testing.T) {
-	path, err := MakePath("twitter", "tweet", "1")
+	path, err := makePath("twitter", "tweet", "1")
 	if err != nil {
 		t.Errorf("Fail to create path: %s", err)
 	}
@@ -120,7 +121,7 @@ func TestMakePath(t *testing.T) {
 		t.Errorf("Wrong path created: %s", path)
 	}
 
-	path, err = MakePath("twitter", "", "_refresh")
+	path, err = makePath("twitter", "", "_refresh")
 	if err != nil {
 		t.Errorf("Fail to create path: %s", err)
 	}
@@ -128,14 +129,14 @@ func TestMakePath(t *testing.T) {
 		t.Errorf("Wrong path created: %s", path)
 	}
 
-	path, err = MakePath("", "", "_bulk")
+	path, err = makePath("", "", "_bulk")
 	if err != nil {
 		t.Errorf("Fail to create path: %s", err)
 	}
 	if path != "/_bulk" {
 		t.Errorf("Wrong path created: %s", path)
 	}
-	path, err = MakePath("twitter", "", "")
+	path, err = makePath("twitter", "", "")
 	if err != nil {
 		t.Errorf("Fail to create path: %s", err)
 	}
@@ -178,7 +179,7 @@ func TestIndex(t *testing.T) {
 	params = map[string]string{
 		"q": "user:test",
 	}
-	result, err := es.SearchUri(index, "test", params)
+	result, err := es.searchURI(index, "test", params)
 	if err != nil {
 		t.Errorf("SearchUri() returns an error: %s", err)
 	}
@@ -197,13 +198,13 @@ func TestReadQueryResult(t *testing.T) {
 	queryResult := GetValidQueryResult()
 
 	json := queryResult.Source
-	result, err := ReadQueryResult(json)
+	result, err := readQueryResult(json)
 
 	assert.Nil(t, err)
 	assert.Equal(t, queryResult.Ok, result.Ok)
 	assert.Equal(t, queryResult.Index, result.Index)
 	assert.Equal(t, queryResult.Type, result.Type)
-	assert.Equal(t, queryResult.Id, result.Id)
+	assert.Equal(t, queryResult.ID, result.ID)
 	assert.Equal(t, queryResult.Version, result.Version)
 	assert.Equal(t, queryResult.Found, result.Found)
 	assert.Equal(t, queryResult.Exists, result.Exists)
@@ -212,7 +213,7 @@ func TestReadQueryResult(t *testing.T) {
 
 // Check empty query result object
 func TestReadQueryResult_empty(t *testing.T) {
-	result, err := ReadQueryResult(nil)
+	result, err := readQueryResult(nil)
 	assert.Nil(t, result)
 	assert.Nil(t, err)
 }
@@ -223,7 +224,7 @@ func TestReadQueryResult_invalid(t *testing.T) {
 	// Invalid json string
 	json := []byte(`{"name":"ruflin","234"}`)
 
-	result, err := ReadQueryResult(json)
+	result, err := readQueryResult(json)
 	assert.Nil(t, result)
 	assert.Error(t, err)
 }
@@ -242,7 +243,7 @@ func TestReadSearchResult(t *testing.T) {
   		"aggs" : {}
   	}`)
 
-	results, err := ReadSearchResult(json)
+	results, err := readSearchResult(json)
 
 	assert.Nil(t, err)
 	assert.Equal(t, resultsObject.Took, results.Took)
@@ -252,7 +253,7 @@ func TestReadSearchResult(t *testing.T) {
 }
 
 func TestReadSearchResult_empty(t *testing.T) {
-	results, err := ReadSearchResult(nil)
+	results, err := readSearchResult(nil)
 	assert.Nil(t, results)
 	assert.Nil(t, err)
 }
@@ -262,7 +263,7 @@ func TestReadSearchResult_invalid(t *testing.T) {
 	// Invalid json string
 	json := []byte(`{"took":"19","234"}`)
 
-	results, err := ReadSearchResult(json)
+	results, err := readSearchResult(json)
 	assert.Nil(t, results)
 	assert.Error(t, err)
 }

--- a/outputs/elasticsearch/bulkapi.go
+++ b/outputs/elasticsearch/bulkapi.go
@@ -13,7 +13,7 @@ import (
 )
 
 type EventMsg struct {
-	Trans outputs.Transactioner
+	Trans outputs.Signaler
 	Ts    time.Time
 	Event common.MapStr
 }

--- a/outputs/elasticsearch/bulkapi.go
+++ b/outputs/elasticsearch/bulkapi.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/elastic/libbeat/common"
 	"github.com/elastic/libbeat/logp"
+	"github.com/elastic/libbeat/outputs"
 )
 
 type EventMsg struct {
+	Trans outputs.Transactioner
 	Ts    time.Time
 	Event common.MapStr
 }

--- a/outputs/elasticsearch/bulkapi_mock_test.go
+++ b/outputs/elasticsearch/bulkapi_mock_test.go
@@ -33,11 +33,10 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 		},
 	}
 
-	body := make(chan interface{}, 10)
+	body := make([]interface{}, 0, 10)
 	for _, op := range ops {
-		body <- op
+		body = append(body, op)
 	}
-	close(body)
 
 	server := ElasticsearchMock(200, expected_resp)
 
@@ -75,11 +74,10 @@ func TestOneHost500Resp_Bulk(t *testing.T) {
 		},
 	}
 
-	body := make(chan interface{}, 10)
+	body := make([]interface{}, 0, 10)
 	for _, op := range ops {
-		body <- op
+		body = append(body, op)
 	}
-	close(body)
 
 	server := ElasticsearchMock(http.StatusInternalServerError, []byte("Something wrong happened"))
 
@@ -118,11 +116,10 @@ func TestOneHost503Resp_Bulk(t *testing.T) {
 		},
 	}
 
-	body := make(chan interface{}, 10)
+	body := make([]interface{}, 0, 10)
 	for _, op := range ops {
-		body <- op
+		body = append(body, op)
 	}
-	close(body)
 
 	server := ElasticsearchMock(503, []byte("Something wrong happened"))
 
@@ -163,11 +160,10 @@ func TestMultipleHost_Bulk(t *testing.T) {
 		},
 	}
 
-	body := make(chan interface{}, 10)
+	body := make([]interface{}, 0, 10)
 	for _, op := range ops {
-		body <- op
+		body = append(body, op)
 	}
-	close(body)
 
 	server1 := ElasticsearchMock(503, []byte("Somehting went wrong"))
 	server2 := ElasticsearchMock(200, expected_resp)

--- a/outputs/elasticsearch/bulkapi_mock_test.go
+++ b/outputs/elasticsearch/bulkapi_mock_test.go
@@ -18,7 +18,7 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 	}
 
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
-	expected_resp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "type1", Id: "1", Version: 1, Created: true})
+	expectedResp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "type1", ID: "1", Version: 1, Created: true})
 
 	ops := []map[string]interface{}{
 		map[string]interface{}{
@@ -38,7 +38,7 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 		body = append(body, op)
 	}
 
-	server := ElasticsearchMock(200, expected_resp)
+	server := ElasticsearchMock(200, expectedResp)
 
 	es := NewElasticsearch([]string{server.URL}, "", "")
 
@@ -145,7 +145,7 @@ func TestMultipleHost_Bulk(t *testing.T) {
 	}
 
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
-	expected_resp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "type1", Id: "1", Version: 1, Created: true})
+	expectedResp, _ := json.Marshal(QueryResult{Ok: true, Index: index, Type: "type1", ID: "1", Version: 1, Created: true})
 
 	ops := []map[string]interface{}{
 		map[string]interface{}{
@@ -166,7 +166,7 @@ func TestMultipleHost_Bulk(t *testing.T) {
 	}
 
 	server1 := ElasticsearchMock(503, []byte("Somehting went wrong"))
-	server2 := ElasticsearchMock(200, expected_resp)
+	server2 := ElasticsearchMock(200, expectedResp)
 
 	es := NewElasticsearch([]string{server1.URL, server2.URL}, "", "")
 

--- a/outputs/elasticsearch/bulkapi_test.go
+++ b/outputs/elasticsearch/bulkapi_test.go
@@ -47,7 +47,7 @@ func TestBulk(t *testing.T) {
 	params = map[string]string{
 		"q": "field1:value1",
 	}
-	result, err := es.SearchUri(index, "type1", params)
+	result, err := es.searchURI(index, "type1", params)
 	if err != nil {
 		t.Errorf("SearchUri() returns an error: %s", err)
 	}
@@ -154,7 +154,7 @@ func TestBulkMoreOperations(t *testing.T) {
 	params = map[string]string{
 		"q": "field1:value3",
 	}
-	result, err := es.SearchUri(index, "type1", params)
+	result, err := es.searchURI(index, "type1", params)
 	if err != nil {
 		t.Errorf("SearchUri() returns an error: %s", err)
 	}
@@ -165,7 +165,7 @@ func TestBulkMoreOperations(t *testing.T) {
 	params = map[string]string{
 		"q": "field2:value2",
 	}
-	result, err = es.SearchUri(index, "type1", params)
+	result, err = es.searchURI(index, "type1", params)
 	if err != nil {
 		t.Errorf("SearchUri() returns an error: %s", err)
 	}

--- a/outputs/elasticsearch/bulkapi_test.go
+++ b/outputs/elasticsearch/bulkapi_test.go
@@ -31,11 +31,10 @@ func TestBulk(t *testing.T) {
 		},
 	}
 
-	body := make(chan interface{}, 10)
+	body := make([]interface{}, 0, 10)
 	for _, op := range ops {
-		body <- op
+		body = append(body, op)
 	}
-	close(body)
 
 	params := map[string]string{
 		"refresh": "true",
@@ -72,8 +71,7 @@ func TestEmptyBulk(t *testing.T) {
 	es := GetTestingElasticsearch()
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
 
-	body := make(chan interface{}, 10)
-	close(body)
+	body := make([]interface{}, 0, 10)
 
 	params := map[string]string{
 		"refresh": "true",
@@ -139,11 +137,10 @@ func TestBulkMoreOperations(t *testing.T) {
 		},
 	}
 
-	body := make(chan interface{}, 10)
+	body := make([]interface{}, 0, 10)
 	for _, op := range ops {
-		body <- op
+		body = append(body, op)
 	}
-	close(body)
 
 	params := map[string]string{
 		"refresh": "true",

--- a/outputs/elasticsearch/connection_pool.go
+++ b/outputs/elasticsearch/connection_pool.go
@@ -84,7 +84,7 @@ func (pool *ConnectionPool) GetConnection() *Connection {
 // timeout = default_timeout * 2 ** (fail_count - 1)
 // When the timeout is over, the connection will be resurrected and
 // returned to the live pool
-func (pool *ConnectionPool) MarkDead(conn *Connection) error {
+func (pool *ConnectionPool) MarkDead(conn *Connection) {
 
 	if !conn.dead {
 		logp.Debug("elasticsearch", "Mark dead %s", conn.Url)
@@ -97,18 +97,15 @@ func (pool *ConnectionPool) MarkDead(conn *Connection) error {
 			logp.Debug("elasticsearch", "Timeout expired. Mark it as alive: %s", conn.Url)
 		})
 	}
-
-	return nil
 }
 
 // A connection that has been previously marked as dead and succeeds will be marked
 // as live and the dead_count is set to zero
-func (pool *ConnectionPool) MarkLive(conn *Connection) error {
+func (pool *ConnectionPool) MarkLive(conn *Connection) {
 	if conn.dead {
 		logp.Debug("elasticsearch", "Mark live %s", conn.Url)
 		conn.dead = false
 		conn.dead_count = 0
 		conn.timer.Stop()
 	}
-	return nil
 }

--- a/outputs/elasticsearch/connection_pool_test.go
+++ b/outputs/elasticsearch/connection_pool_test.go
@@ -21,13 +21,13 @@ func TestRoundRobin(t *testing.T) {
 
 	conn := pool.GetConnection()
 
-	if conn.Url != "localhost:9200" {
-		t.Errorf("Wrong connection returned: %s", conn.Url)
+	if conn.URL != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.URL)
 	}
 
 	conn = pool.GetConnection()
-	if conn.Url != "localhost:9201" {
-		t.Errorf("Wrong connection returned: %s", conn.Url)
+	if conn.URL != "localhost:9201" {
+		t.Errorf("Wrong connection returned: %s", conn.URL)
 	}
 }
 
@@ -45,24 +45,24 @@ func TestMarkDead(t *testing.T) {
 
 	conn := pool.GetConnection()
 
-	if conn.Url != "localhost:9200" {
-		t.Errorf("Wrong connection returned: %s", conn.Url)
+	if conn.URL != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.URL)
 	}
 	pool.MarkDead(conn)
 
 	conn = pool.GetConnection()
-	if conn.Url != "localhost:9201" {
-		t.Errorf("Wrong connection returned: %s", conn.Url)
+	if conn.URL != "localhost:9201" {
+		t.Errorf("Wrong connection returned: %s", conn.URL)
 	}
 
 	conn = pool.GetConnection()
-	if conn.Url != "localhost:9201" {
-		t.Errorf("Wrong connection returned: %s", conn.Url)
+	if conn.URL != "localhost:9201" {
+		t.Errorf("Wrong connection returned: %s", conn.URL)
 	}
 	pool.MarkDead(conn)
 
 	conn = pool.GetConnection()
-	if conn.Url != "localhost:9201" && conn.Url != "localhost:9200" {
+	if conn.URL != "localhost:9201" && conn.URL != "localhost:9200" {
 		t.Errorf("No expected connection returned")
 	}
 
@@ -86,20 +86,20 @@ func TestDeadTimeout(t *testing.T) {
 
 	conn := pool.GetConnection()
 
-	if conn.Url != "localhost:9200" {
-		t.Errorf("Wrong connection returned: %s", conn.Url)
+	if conn.URL != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.URL)
 	}
 	pool.MarkDead(conn)
 	time.Sleep(10 * time.Second)
 
 	conn = pool.GetConnection()
-	if conn.Url != "localhost:9201" {
-		t.Errorf("Wrong connection returned: %s", conn.Url)
+	if conn.URL != "localhost:9201" {
+		t.Errorf("Wrong connection returned: %s", conn.URL)
 	}
 
 	conn = pool.GetConnection()
-	if conn.Url != "localhost:9200" {
-		t.Errorf("Wrong connection returned: %s", conn.Url)
+	if conn.URL != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.URL)
 	}
 }
 
@@ -116,19 +116,19 @@ func TestMarkLive(t *testing.T) {
 	}
 
 	conn := pool.GetConnection()
-	if conn.Url != "localhost:9200" {
-		t.Errorf("Wrong connection returned: %s", conn.Url)
+	if conn.URL != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.URL)
 	}
 	pool.MarkDead(conn)
 	pool.MarkLive(conn)
 
 	conn = pool.GetConnection()
-	if conn.Url != "localhost:9201" {
-		t.Errorf("Wrong connection returned: %s", conn.Url)
+	if conn.URL != "localhost:9201" {
+		t.Errorf("Wrong connection returned: %s", conn.URL)
 	}
 	conn = pool.GetConnection()
-	if conn.Url != "localhost:9200" {
-		t.Errorf("Wrong connection returned: %s", conn.Url)
+	if conn.URL != "localhost:9200" {
+		t.Errorf("Wrong connection returned: %s", conn.URL)
 	}
 
 }

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -23,11 +23,11 @@ type elasticsearchOutputPlugin struct{}
 // NewOutput instantiates a new output plugin instance publishing to elasticsearch.
 func (f elasticsearchOutputPlugin) NewOutput(
 	beat string,
-	config outputs.MothershipConfig,
+	config *outputs.MothershipConfig,
 	TopologyExpire int,
 ) (outputs.Outputer, error) {
 	output := &elasticsearchOutput{}
-	err := output.Init(beat, config, TopologyExpire)
+	err := output.Init(beat, *config, TopologyExpire)
 	if err != nil {
 		return nil, err
 	}

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -118,7 +118,7 @@ func TestOneEvent(t *testing.T) {
 		},
 	})
 
-	err := elasticsearchOutput.PublishEvent(ts, event)
+	err := elasticsearchOutput.PublishEvent(nil, ts, event)
 	if err != nil {
 		t.Errorf("Failed to publish the event: %s", err)
 	}
@@ -189,7 +189,7 @@ func TestEvents(t *testing.T) {
 		},
 	})
 
-	err := elasticsearchOutput.PublishEvent(ts, event)
+	err := elasticsearchOutput.PublishEvent(nil, ts, event)
 	if err != nil {
 		t.Errorf("Failed to publish the event: %s", err)
 	}
@@ -199,7 +199,7 @@ func TestEvents(t *testing.T) {
 	r["response"] = 0
 	event["redis"] = r
 
-	err = elasticsearchOutput.PublishEvent(ts, event)
+	err = elasticsearchOutput.PublishEvent(nil, ts, event)
 	if err != nil {
 		t.Errorf("Failed to publish the event: %s", err)
 	}
@@ -258,7 +258,7 @@ func test_bulk_with_params(t *testing.T, elasticsearchOutput elasticsearchOutput
 		r["response"] = "value" + strconv.Itoa(i)
 		event["redis"] = r
 
-		err := elasticsearchOutput.PublishEvent(ts, event)
+		err := elasticsearchOutput.PublishEvent(nil, ts, event)
 		if err != nil {
 			t.Errorf("Failed to publish the event: %s", err)
 		}

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/elastic/libbeat/outputs"
 )
 
-func createElasticsearchConnection(flush_interval int, bulk_size int) elasticsearchOutput {
+func createElasticsearchConnection(flushInterval int, bulkSize int) elasticsearchOutput {
 
 	index := fmt.Sprintf("packetbeat-unittest-%d", os.Getpid())
 
@@ -22,9 +22,8 @@ func createElasticsearchConnection(flush_interval int, bulk_size int) elasticsea
 		logp.Err("Invalid port. Cannot be converted to in: %s", GetEsPort())
 	}
 
-	var elasticsearchOutput elasticsearchOutput
-
-	elasticsearchOutput.Init("packetbeat", outputs.MothershipConfig{
+	var output elasticsearchOutput
+	output.Init("packetbeat", outputs.MothershipConfig{
 		Enabled:        true,
 		Save_topology:  true,
 		Host:           GetEsHost(),
@@ -34,11 +33,11 @@ func createElasticsearchConnection(flush_interval int, bulk_size int) elasticsea
 		Path:           "",
 		Index:          index,
 		Protocol:       "",
-		Flush_interval: &flush_interval,
-		Bulk_size:      &bulk_size,
+		Flush_interval: &flushInterval,
+		Bulk_size:      &bulkSize,
 	}, 10)
 
-	return elasticsearchOutput
+	return output
 }
 
 func TestTopologyInES(t *testing.T) {
@@ -141,7 +140,7 @@ func TestOneEvent(t *testing.T) {
 	params := map[string]string{
 		"q": "shipper:appserver1",
 	}
-	resp, err := elasticsearchOutput.Conn.SearchUri(index, "", params)
+	resp, err := elasticsearchOutput.Conn.searchURI(index, "", params)
 
 	if err != nil {
 		t.Errorf("Failed to query elasticsearch for index(%s): %s", index, err)
@@ -220,7 +219,7 @@ func TestEvents(t *testing.T) {
 		}
 	}()
 
-	resp, err := elasticsearchOutput.Conn.SearchUri(index, "", params)
+	resp, err := elasticsearchOutput.Conn.searchURI(index, "", params)
 
 	if err != nil {
 		t.Errorf("Failed to query elasticsearch: %s", err)
@@ -230,7 +229,7 @@ func TestEvents(t *testing.T) {
 	}
 }
 
-func test_bulk_with_params(t *testing.T, elasticsearchOutput elasticsearchOutput) {
+func testBulkWithParams(t *testing.T, elasticsearchOutput elasticsearchOutput) {
 	ts := time.Now()
 	index := fmt.Sprintf("%s-%d.%02d.%02d", elasticsearchOutput.Index, ts.Year(), ts.Month(), ts.Day())
 
@@ -281,7 +280,7 @@ func test_bulk_with_params(t *testing.T, elasticsearchOutput elasticsearchOutput
 		}
 	}()
 
-	resp, err := elasticsearchOutput.Conn.SearchUri(index, "", params)
+	resp, err := elasticsearchOutput.Conn.searchURI(index, "", params)
 
 	if err != nil {
 		t.Errorf("Failed to query elasticsearch: %s", err)
@@ -301,13 +300,13 @@ func TestBulkEvents(t *testing.T) {
 	}
 
 	elasticsearchOutput := createElasticsearchConnection(50, 2)
-	test_bulk_with_params(t, elasticsearchOutput)
+	testBulkWithParams(t, elasticsearchOutput)
 
 	elasticsearchOutput = createElasticsearchConnection(50, 1000)
-	test_bulk_with_params(t, elasticsearchOutput)
+	testBulkWithParams(t, elasticsearchOutput)
 
 	elasticsearchOutput = createElasticsearchConnection(50, 5)
-	test_bulk_with_params(t, elasticsearchOutput)
+	testBulkWithParams(t, elasticsearchOutput)
 }
 
 func TestEnableTTL(t *testing.T) {

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -42,7 +42,6 @@ func createElasticsearchConnection(flush_interval int, bulk_size int) elasticsea
 }
 
 func TestTopologyInES(t *testing.T) {
-
 	if testing.Short() {
 		t.Skip("Skipping topology tests in short mode, because they require Elasticsearch")
 	}

--- a/outputs/fileout/file.go
+++ b/outputs/fileout/file.go
@@ -17,7 +17,7 @@ type FileOutputPlugin struct{}
 
 func (f FileOutputPlugin) NewOutput(
 	beat string,
-	config outputs.MothershipConfig,
+	config *outputs.MothershipConfig,
 	topology_expire int,
 ) (outputs.Outputer, error) {
 	output := &fileOutput{}
@@ -32,12 +32,17 @@ type fileOutput struct {
 	rotator logp.FileRotator
 }
 
-func (out *fileOutput) init(beat string, config outputs.MothershipConfig, topology_expire int) error {
+func (out *fileOutput) init(beat string, config *outputs.MothershipConfig, topology_expire int) error {
 	out.rotator.Path = config.Path
 	out.rotator.Name = config.Filename
 	if out.rotator.Name == "" {
 		out.rotator.Name = beat
 	}
+
+	// disable bulk support
+	configDisableInt := -1
+	config.Flush_interval = &configDisableInt
+	config.Bulk_size = &configDisableInt
 
 	rotateeverybytes := uint64(config.Rotate_every_kb) * 1024
 	if rotateeverybytes == 0 {

--- a/outputs/fileout/file.go
+++ b/outputs/fileout/file.go
@@ -65,20 +65,20 @@ func (out *fileOutput) init(beat string, config outputs.MothershipConfig, topolo
 }
 
 func (out *fileOutput) PublishEvent(
-	trans outputs.Transactioner,
+	trans outputs.Signaler,
 	ts time.Time,
 	event common.MapStr,
 ) error {
 	jsonEvent, err := json.Marshal(event)
 	if err != nil {
 		// mark as success so event is not send again.
-		outputs.CompleteTransaction(trans)
+		outputs.SignalCompleted(trans)
 
 		logp.Err("Fail to convert the event to JSON: %s", err)
 		return err
 	}
 
 	err = out.rotator.WriteLine(jsonEvent)
-	outputs.FinishTransaction(trans, err)
+	outputs.Signal(trans, err)
 	return err
 }

--- a/outputs/lumberjack/lumberjack.go
+++ b/outputs/lumberjack/lumberjack.go
@@ -131,7 +131,7 @@ func makeClients(
 //       processing (e.g. for filebeat). Batch like processing might reduce
 //       send/receive overhead per event for other implementors too.
 func (lj *lumberjack) PublishEvent(
-	trans outputs.Transactioner,
+	trans outputs.Signaler,
 	ts time.Time,
 	event common.MapStr,
 ) error {
@@ -142,7 +142,7 @@ func (lj *lumberjack) PublishEvent(
 // BulkPublish implements the BulkOutputer interface pushing a bulk of events
 // via lumberjack.
 func (lj *lumberjack) BulkPublish(
-	trans outputs.Transactioner,
+	trans outputs.Signaler,
 	ts time.Time,
 	events []common.MapStr,
 ) error {

--- a/outputs/lumberjack/lumberjack.go
+++ b/outputs/lumberjack/lumberjack.go
@@ -8,8 +8,11 @@ import (
 	"time"
 
 	"github.com/elastic/libbeat/common"
+	"github.com/elastic/libbeat/logp"
 	"github.com/elastic/libbeat/outputs"
 )
+
+var debug = logp.MakeDebug("lumberjack")
 
 func init() {
 	outputs.RegisterOutputPlugin("lumberjack", lumberjackOutputPlugin{})
@@ -108,7 +111,7 @@ func makeClients(
 			transp, err := newTransp(host)
 			if err != nil {
 				for _, client := range clients {
-					client.Close()
+					_ = client.Close() // ignore error
 				}
 				return nil, err
 			}

--- a/outputs/lumberjack/lumberjack.go
+++ b/outputs/lumberjack/lumberjack.go
@@ -22,11 +22,11 @@ type lumberjackOutputPlugin struct{}
 
 func (p lumberjackOutputPlugin) NewOutput(
 	beat string,
-	config outputs.MothershipConfig,
+	config *outputs.MothershipConfig,
 	topologyExpire int,
 ) (outputs.Outputer, error) {
 	output := &lumberjack{}
-	err := output.init(beat, config, topologyExpire)
+	err := output.init(beat, *config, topologyExpire)
 	if err != nil {
 		return nil, err
 	}

--- a/outputs/lumberjack/lumberjack.go
+++ b/outputs/lumberjack/lumberjack.go
@@ -130,13 +130,21 @@ func makeClients(
 // TODO: update Outputer interface to support multiple events for batch-like
 //       processing (e.g. for filebeat). Batch like processing might reduce
 //       send/receive overhead per event for other implementors too.
-func (lj *lumberjack) PublishEvent(ts time.Time, event common.MapStr) error {
+func (lj *lumberjack) PublishEvent(
+	trans outputs.Transactioner,
+	ts time.Time,
+	event common.MapStr,
+) error {
 	events := []common.MapStr{event}
-	return lj.mode.PublishEvents(events)
+	return lj.mode.PublishEvents(trans, events)
 }
 
 // BulkPublish implements the BulkOutputer interface pushing a bulk of events
 // via lumberjack.
-func (lj *lumberjack) BulkPublish(ts time.Time, events []common.MapStr) error {
-	return lj.mode.PublishEvents(events)
+func (lj *lumberjack) BulkPublish(
+	trans outputs.Transactioner,
+	ts time.Time,
+	events []common.MapStr,
+) error {
+	return lj.mode.PublishEvents(trans, events)
 }

--- a/outputs/lumberjack/lumberjack_test.go
+++ b/outputs/lumberjack/lumberjack_test.go
@@ -32,7 +32,7 @@ func newTestLumberjackOutput(
 		t.Fatalf("No lumberjack output plugin found")
 	}
 
-	output, err := plugin.NewOutput("test", config, 0)
+	output, err := plugin.NewOutput("test", &config, 0)
 	if err != nil {
 		t.Fatalf("init lumberjack output plugin failed: %v", err)
 	}

--- a/outputs/lumberjack/lumberjack_test.go
+++ b/outputs/lumberjack/lumberjack_test.go
@@ -208,7 +208,7 @@ func TestLumberjackTCP(t *testing.T) {
 
 	// send event to server
 	event := common.MapStr{"name": "me", "line": 10}
-	output.PublishEvent(time.Now(), event)
+	output.PublishEvent(nil, time.Now(), event)
 
 	wg.Wait()
 	listener.Close()
@@ -316,7 +316,7 @@ func TestLumberjackTLS(t *testing.T) {
 		output := newTestLumberjackOutput(t, config)
 
 		event := common.MapStr{"name": "me", "line": 10}
-		output.PublishEvent(time.Now(), event)
+		output.PublishEvent(nil, time.Now(), event)
 	}()
 
 	wg.Wait()

--- a/outputs/lumberjack/modes.go
+++ b/outputs/lumberjack/modes.go
@@ -53,7 +53,7 @@ type ConnectionMode interface {
 
 	// PublishEvents will send all events (potentially asynchronous) to its
 	// clients.
-	PublishEvents(trans outputs.Transactioner, events []common.MapStr) error
+	PublishEvents(trans outputs.Signaler, events []common.MapStr) error
 }
 
 type singleConnectionMode struct {
@@ -107,7 +107,7 @@ func (s *singleConnectionMode) Close() error {
 }
 
 func (s *singleConnectionMode) PublishEvents(
-	trans outputs.Transactioner,
+	trans outputs.Signaler,
 	events []common.MapStr,
 ) error {
 	published := 0
@@ -127,12 +127,12 @@ func (s *singleConnectionMode) PublishEvents(
 		}
 
 		if published == len(events) {
-			outputs.CompleteTransaction(trans)
+			outputs.SignalCompleted(trans)
 			return nil
 		}
 	}
 
-	outputs.FailTransaction(trans)
+	outputs.SignalFailed(trans)
 	return nil
 }
 
@@ -206,7 +206,7 @@ func (f *failOverConnectionMode) Connect(active int) error {
 }
 
 func (f *failOverConnectionMode) PublishEvents(
-	trans outputs.Transactioner,
+	trans outputs.Signaler,
 	events []common.MapStr,
 ) error {
 	published := 0
@@ -233,11 +233,11 @@ func (f *failOverConnectionMode) PublishEvents(
 		}
 
 		if published == len(events) {
-			outputs.CompleteTransaction(trans)
+			outputs.SignalCompleted(trans)
 			return nil
 		}
 	}
 
-	outputs.FailTransaction(trans)
+	outputs.SignalFailed(trans)
 	return nil
 }

--- a/outputs/lumberjack/modes.go
+++ b/outputs/lumberjack/modes.go
@@ -90,7 +90,7 @@ func newSingleConnectionMode(
 		conn:    client,
 	}
 
-	s.Connect() // try to connect, but ignore errors for now
+	_ = s.Connect() // try to connect, but ignore errors for now
 	return s, nil
 }
 
@@ -146,7 +146,10 @@ func newFailOverConnectionMode(
 		timeout:   timeout,
 		waitRetry: waitRetry,
 	}
-	f.Connect(-1)
+
+	// Try to connect preliminary, but ignore errors for now.
+	// Main publisher loop is responsible to ensure an available connection.
+	_ = f.Connect(-1)
 	return f, nil
 }
 
@@ -155,7 +158,7 @@ func (f *failOverConnectionMode) Close() error {
 		f.closed = true
 		for _, conn := range f.conns {
 			if conn.IsConnected() {
-				conn.Close()
+				_ = conn.Close()
 			}
 		}
 	}

--- a/outputs/lumberjack/modes.go
+++ b/outputs/lumberjack/modes.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/elastic/libbeat/common"
+	"github.com/elastic/libbeat/outputs"
 )
 
 // ProtocolClient interface is a output plugin specific client implementation
@@ -52,7 +53,7 @@ type ConnectionMode interface {
 
 	// PublishEvents will send all events (potentially asynchronous) to its
 	// clients.
-	PublishEvents(events []common.MapStr) error
+	PublishEvents(trans outputs.Transactioner, events []common.MapStr) error
 }
 
 type singleConnectionMode struct {
@@ -105,22 +106,33 @@ func (s *singleConnectionMode) Close() error {
 	return s.conn.Close()
 }
 
-func (s *singleConnectionMode) PublishEvents(events []common.MapStr) error {
+func (s *singleConnectionMode) PublishEvents(
+	trans outputs.Transactioner,
+	events []common.MapStr,
+) error {
+	published := 0
 	for !s.closed {
 		if err := s.Connect(); err != nil {
 			time.Sleep(s.waitRetry)
 			continue
 		}
 
-		for published := 0; published < len(events); {
+		for published < len(events) {
 			n, err := s.conn.PublishEvents(events[published:])
 			if err != nil {
-				continue
+				break
 			}
+
 			published += n
 		}
-		break
+
+		if published == len(events) {
+			outputs.CompleteTransaction(trans)
+			return nil
+		}
 	}
+
+	outputs.FailTransaction(trans)
 	return nil
 }
 
@@ -193,14 +205,18 @@ func (f *failOverConnectionMode) Connect(active int) error {
 	return errNoActiveConnection
 }
 
-func (f *failOverConnectionMode) PublishEvents(events []common.MapStr) error {
+func (f *failOverConnectionMode) PublishEvents(
+	trans outputs.Transactioner,
+	events []common.MapStr,
+) error {
+	published := 0
 	for !f.closed {
 		if err := f.Connect(f.active); err != nil {
 			continue
 		}
 
 		// loop until all events have been send in case client supports partial sends
-		for published := 0; published < len(events); {
+		for published < len(events) {
 			conn := f.conns[f.active]
 			n, err := conn.PublishEvents(events[published:])
 			if err != nil {
@@ -215,8 +231,13 @@ func (f *failOverConnectionMode) PublishEvents(events []common.MapStr) error {
 			}
 			published += n
 		}
-		break
+
+		if published == len(events) {
+			outputs.CompleteTransaction(trans)
+			return nil
+		}
 	}
 
+	outputs.FailTransaction(trans)
 	return nil
 }

--- a/outputs/lumberjack/modes_test.go
+++ b/outputs/lumberjack/modes_test.go
@@ -97,7 +97,7 @@ func TestSingleSend(t *testing.T) {
 	)
 
 	events := []common.MapStr{common.MapStr{"hello": "world"}}
-	err := mode.PublishEvents(events)
+	err := mode.PublishEvents(nil, events)
 	mode.Close()
 
 	assert.Nil(t, err)
@@ -120,7 +120,7 @@ func TestSingleConnectFailConnect(t *testing.T) {
 	)
 
 	events := []common.MapStr{common.MapStr{"hello": "world"}}
-	err := mode.PublishEvents(events)
+	err := mode.PublishEvents(nil, events)
 	mode.Close()
 
 	assert.Nil(t, err)
@@ -151,7 +151,7 @@ func TestFailoverSingleSend(t *testing.T) {
 
 	events := []common.MapStr{common.MapStr{"hello": "world"}}
 
-	err := mode.PublishEvents(events)
+	err := mode.PublishEvents(nil, events)
 	mode.Close()
 
 	assert.Nil(t, err)
@@ -183,7 +183,7 @@ func TestFailoverFlakyConnections(t *testing.T) {
 
 	events := []common.MapStr{common.MapStr{"hello": "world"}}
 	for i := 0; i < 10; i++ {
-		mode.PublishEvents(events)
+		mode.PublishEvents(nil, events)
 	}
 
 	mode.Close()

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -1,7 +1,6 @@
 package outputs
 
 import (
-	"sync/atomic"
 	"time"
 
 	"github.com/elastic/libbeat/common"
@@ -38,7 +37,7 @@ type MothershipConfig struct {
 
 type Outputer interface {
 	// Publish event
-	PublishEvent(trans Transactioner, ts time.Time, event common.MapStr) error
+	PublishEvent(trans Signaler, ts time.Time, event common.MapStr) error
 }
 
 type TopologyOutputer interface {
@@ -53,7 +52,7 @@ type TopologyOutputer interface {
 // Outputers still might loop on events or use more efficient bulk-apis if present.
 type BulkOutputer interface {
 	Outputer
-	BulkPublish(trans Transactioner, ts time.Time, event []common.MapStr) error
+	BulkPublish(trans Signaler, ts time.Time, event []common.MapStr) error
 }
 
 type OutputBuilder interface {
@@ -70,31 +69,10 @@ type OutputInterface interface {
 	TopologyOutputer
 }
 
-type Transactioner interface {
-	// Completed is called by publish/output plugin when all events have been
-	// send
-	Completed()
-	Failed()
-}
-
 type OutputPlugin struct {
 	Name   string
 	Config MothershipConfig
 	Output Outputer
-}
-
-// MultiOutputTransaction guards one transaction from multiple calls
-// by using a simple reference counting scheme. If one Transactioner consumer
-// reports a Failed event, the Failed event will be send to the guarded Transactioner
-// once the reference count becomes zero.
-//
-// Example use cases:
-//   - Push transaction to multiple outputers
-//   - split data to be send into smaller transactions
-type MultiOutputTransaction struct {
-	count       int32
-	failed      bool
-	transaction Transactioner
 }
 
 type bulkOutputAdapter struct {
@@ -146,95 +124,16 @@ func CastBulkOutputer(out Outputer) BulkOutputer {
 }
 
 func (b *bulkOutputAdapter) BulkPublish(
-	trans Transactioner,
+	signal Signaler,
 	ts time.Time,
 	events []common.MapStr,
 ) error {
-	trans = NewMultiOutputTransaction(trans, len(events))
+	signal = NewSplitSignaler(signal, len(events))
 	for _, evt := range events {
-		err := b.PublishEvent(trans, ts, evt)
+		err := b.PublishEvent(signal, ts, evt)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-// NewMultiOutputTransaction create a new MultiOutputTransaction if trans is not nil.
-// If trans is nil, nil will be returned. The count is the number of events to be
-// received before publishing the final event to the guarded Transactioner.
-func NewMultiOutputTransaction(
-	trans Transactioner,
-	count int,
-) *MultiOutputTransaction {
-	if trans == nil {
-		return nil
-	}
-
-	return &MultiOutputTransaction{
-		count:       int32(count),
-		transaction: trans,
-	}
-}
-
-// Completed signals a Completed event to m.
-func (m *MultiOutputTransaction) Completed() {
-	m.onEvent()
-}
-
-// Failed signals a Failed event to m.
-func (m *MultiOutputTransaction) Failed() {
-	m.failed = true
-	m.onEvent()
-}
-
-func (m *MultiOutputTransaction) onEvent() {
-	res := atomic.AddInt32(&m.count, -1)
-	if res == 0 {
-		if m.failed {
-			m.transaction.Failed()
-		} else {
-			m.transaction.Completed()
-		}
-	}
-}
-
-// CompleteTransaction sends the Completed event to trans if trans is not nil.
-func CompleteTransaction(trans Transactioner) {
-	if trans != nil {
-		trans.Completed()
-	}
-}
-
-// FailTransaction sends the Failed event to trans if trans is not nil
-func FailTransaction(trans Transactioner) {
-	if trans != nil {
-		trans.Failed()
-	}
-}
-
-// FinishTransaction will send the Completed or Failed event to trans depending
-// on err being set if trans is not nil.
-func FinishTransaction(trans Transactioner, err error) {
-	if trans != nil {
-		if err == nil {
-			trans.Completed()
-		} else {
-			trans.Failed()
-		}
-	}
-}
-
-// FinishTransactions send the Completed or Failed event to all given transactions
-// depending on err being set.
-func FinishTransactions(transactions []Transactioner, err error) {
-	if err == nil {
-		for _, t := range transactions {
-			t.Completed()
-		}
-	} else {
-		for _, t := range transactions {
-			t.Failed()
-		}
-	}
 }

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -59,8 +59,8 @@ type OutputBuilder interface {
 	// Create and initialize the output plugin
 	NewOutput(
 		beat string,
-		config MothershipConfig,
-		topology_expire int) (Outputer, error)
+		config *MothershipConfig,
+		topologyExpire int) (Outputer, error)
 }
 
 // Functions to be exported by a output plugin
@@ -101,7 +101,7 @@ func InitOutputs(
 			continue
 		}
 
-		output, err := plugin.NewOutput(beat, config, topologyExpire)
+		output, err := plugin.NewOutput(beat, &config, topologyExpire)
 		if err != nil {
 			logp.Err("failed to initialize %s plugin as output: %s", name, err)
 			return nil, err

--- a/outputs/redis/redis.go
+++ b/outputs/redis/redis.go
@@ -23,11 +23,11 @@ type RedisOutputPlugin struct{}
 
 func (f RedisOutputPlugin) NewOutput(
 	beat string,
-	config outputs.MothershipConfig,
+	config *outputs.MothershipConfig,
 	topology_expire int,
 ) (outputs.Outputer, error) {
 	output := &redisOutput{}
-	err := output.Init(beat, config, topology_expire)
+	err := output.Init(beat, *config, topology_expire)
 	if err != nil {
 		return nil, err
 	}

--- a/outputs/signal.go
+++ b/outputs/signal.go
@@ -1,0 +1,131 @@
+package outputs
+
+import "sync/atomic"
+
+// Signaler signals the completion of potentially asynchronous output operation.
+// Completed is send by output plugin when all events have been send. On failure or
+// only subset of data being published Failed will be send.
+type Signaler interface {
+	Completed()
+
+	Failed()
+}
+
+// SplitSignal guards one output signaler from multiple calls
+// by using a simple reference counting scheme. If one Signaler consumer
+// reports a Failed event, the Failed event will be send to the guarded Signaler
+// once the reference count becomes zero.
+//
+// Example use cases:
+//   - Push signaler to multiple outputers
+//   - split data to be send in smaller batches
+type SplitSignal struct {
+	count    int32
+	failed   bool
+	signaler Signaler
+}
+
+// CompositeSignal combines multiple signalers into one Signaler forwarding an event to
+// to all signalers.
+type CompositeSignal struct {
+	signalers []Signaler
+}
+
+// NewSplitSignaler creates a new SplitSignal if s is not nil.
+// If s is nil, nil will be returned. The count is the number of events to be
+// received before publishing the final event to the guarded Signaler.
+func NewSplitSignaler(
+	s Signaler,
+	count int,
+) *SplitSignal {
+	if s == nil {
+		return nil
+	}
+
+	return &SplitSignal{
+		count:    int32(count),
+		signaler: s,
+	}
+}
+
+// Completed signals a Completed event to s.
+func (s *SplitSignal) Completed() {
+	s.onEvent()
+}
+
+// Failed signals a Failed event to s.
+func (s *SplitSignal) Failed() {
+	s.failed = true
+	s.onEvent()
+}
+
+func (s *SplitSignal) onEvent() {
+	res := atomic.AddInt32(&s.count, -1)
+	if res == 0 {
+		if s.failed {
+			s.signaler.Failed()
+		} else {
+			s.signaler.Completed()
+		}
+	}
+}
+
+// NewCompositeSignaler creates a new composite signaler.
+func NewCompositeSignaler(signalers ...Signaler) *CompositeSignal {
+	if len(signalers) == 0 {
+		return nil
+	}
+	return &CompositeSignal{signalers}
+}
+
+// Completed sends the Completed signal to all signalers.
+func (cs *CompositeSignal) Completed() {
+	for _, s := range cs.signalers {
+		if s != nil {
+			cs.Completed()
+		}
+	}
+}
+
+// Failed sends the Failed signal to all signalers.
+func (cs *CompositeSignal) Failed() {
+	for _, s := range cs.signalers {
+		if s != nil {
+			cs.Failed()
+		}
+	}
+}
+
+// SignalCompleted sends the Completed event to s if s is not nil.
+func SignalCompleted(s Signaler) {
+	if s != nil {
+		s.Completed()
+	}
+}
+
+// SignalFailed sends the Failed event to s if s is not nil
+func SignalFailed(s Signaler) {
+	if s != nil {
+		s.Failed()
+	}
+}
+
+// Signal will send the Completed or Failed event to s depending
+// on err being set if s is not nil.
+func Signal(s Signaler, err error) {
+	if s != nil {
+		if err == nil {
+			s.Completed()
+		} else {
+			s.Failed()
+		}
+	}
+}
+
+// SignalAll send the Completed or Failed event to all given signalers
+// depending on err being set.
+func SignalAll(signalers []Signaler, err error) {
+	if signalers != nil {
+		Signal(NewCompositeSignaler(signalers...), err)
+	}
+}

--- a/publisher/async.go
+++ b/publisher/async.go
@@ -1,31 +1,57 @@
 package publisher
 
 import (
+	"time"
+
 	"github.com/elastic/libbeat/common"
+	"github.com/elastic/libbeat/logp"
 	"github.com/elastic/libbeat/outputs"
 )
 
 type asyncPublisher struct {
 	messageWorker
-	pub *PublisherType
+	outputs []worker
+	pub     *PublisherType
+	ws      workerSignal
 }
 
 type asyncClient func(message)
 
+const (
+	defaultFlushInterval = 1000 * time.Millisecond // 1s
+	defaultBulkSize      = 10000
+)
+
 func newAsyncPublisher(pub *PublisherType) *asyncPublisher {
+
 	p := &asyncPublisher{pub: pub}
+	p.ws.Init()
+
+	var outputs []worker
+	for _, out := range pub.Output {
+		outputs = append(outputs, asyncOutputer(&p.ws, out))
+	}
+
+	p.outputs = outputs
 	p.messageWorker.init(&pub.wsPublisher, 1000, newPreprocessor(pub, p))
 	return p
 }
 
+// onStop will send stop signal to message batching workers
+func (p *asyncPublisher) onStop() { p.ws.stop() }
+
 func (p *asyncPublisher) onMessage(m message) {
+	debug("async forward to outputers (%v)", len(p.outputs))
+
 	// m.signal is not set yet. But a async client type supporting signals might
 	// be implemented in the furute.
 	// If m.signal is nil, NewSplitSignaler will return nil -> signaler will
 	// only set if client did send one
-	m.signal = outputs.NewSplitSignaler(m.signal, len(p.pub.Output))
-	for _, o := range p.pub.Output {
-		o.publish(m)
+	if m.signal != nil && len(p.outputs) > 1 {
+		m.signal = outputs.NewSplitSignaler(m.signal, len(p.outputs))
+	}
+	for _, o := range p.outputs {
+		o.send(m)
 	}
 }
 
@@ -34,11 +60,38 @@ func (p *asyncPublisher) client() EventPublisher {
 }
 
 func (c asyncClient) PublishEvent(event common.MapStr) bool {
-	c(message{event: event})
-	return true
+	return c.send(message{event: event})
 }
 
 func (c asyncClient) PublishEvents(events []common.MapStr) bool {
-	c(message{events: events})
+	return c.send(message{events: events})
+}
+
+func (c asyncClient) send(m message) bool {
+	logp.Debug("publish", "send async event")
+	c(m)
 	return true
+}
+
+func asyncOutputer(ws *workerSignal, worker *outputWorker) worker {
+	config := worker.config
+
+	flushInterval := defaultFlushInterval
+	if config.Flush_interval != nil {
+		flushInterval = time.Duration(*config.Flush_interval) * time.Millisecond
+	}
+
+	maxBulkSize := defaultBulkSize
+	if config.Bulk_size != nil {
+		maxBulkSize = *config.Bulk_size
+	}
+
+	// batching disabled
+	if flushInterval < 0 || maxBulkSize < 0 {
+		return worker
+	}
+
+	debug("create bulk processing worker (interval=%v, bulk size=%v)",
+		flushInterval, maxBulkSize)
+	return newBulkWorker(ws, 1000, worker, flushInterval, maxBulkSize)
 }

--- a/publisher/async.go
+++ b/publisher/async.go
@@ -1,0 +1,44 @@
+package publisher
+
+import (
+	"github.com/elastic/libbeat/common"
+	"github.com/elastic/libbeat/outputs"
+)
+
+type asyncPublisher struct {
+	messageWorker
+	pub *PublisherType
+}
+
+type asyncClient func(message)
+
+func newAsyncPublisher(pub *PublisherType) *asyncPublisher {
+	p := &asyncPublisher{pub: pub}
+	p.messageWorker.init(&pub.wsPublisher, 1000, newPreprocessor(pub, p))
+	return p
+}
+
+func (p *asyncPublisher) onMessage(m message) {
+	// m.signal is not set yet. But a async client type supporting signals might
+	// be implemented in the furute.
+	// If m.signal is nil, NewSplitSignaler will return nil -> signaler will
+	// only set if client did send one
+	m.signal = outputs.NewSplitSignaler(m.signal, len(p.pub.Output))
+	for _, o := range p.pub.Output {
+		o.publish(m)
+	}
+}
+
+func (p *asyncPublisher) client() EventPublisher {
+	return asyncClient(p.send)
+}
+
+func (c asyncClient) PublishEvent(event common.MapStr) bool {
+	c(message{event: event})
+	return true
+}
+
+func (c asyncClient) PublishEvents(events []common.MapStr) bool {
+	c(message{events: events})
+	return true
+}

--- a/publisher/async.go
+++ b/publisher/async.go
@@ -55,7 +55,7 @@ func (p *asyncPublisher) onMessage(m message) {
 	}
 }
 
-func (p *asyncPublisher) client() EventPublisher {
+func (p *asyncPublisher) client() eventPublisher {
 	return asyncClient(p.send)
 }
 

--- a/publisher/bulk.go
+++ b/publisher/bulk.go
@@ -1,0 +1,127 @@
+package publisher
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/elastic/libbeat/common"
+	"github.com/elastic/libbeat/logp"
+	"github.com/elastic/libbeat/outputs"
+)
+
+type bulkWorker struct {
+	output worker
+	ws     *workerSignal
+
+	queue       chan message
+	flushTicker *time.Ticker
+
+	maxBatchSize int
+	events       []common.MapStr    // batched events
+	pending      []outputs.Signaler // pending signalers for batched events
+}
+
+func newBulkWorker(
+	ws *workerSignal, hwm int, output worker,
+	flushInterval time.Duration,
+	maxBatchSize int,
+) *bulkWorker {
+	b := &bulkWorker{
+		output:       output,
+		ws:           ws,
+		queue:        make(chan message, hwm),
+		flushTicker:  time.NewTicker(flushInterval),
+		maxBatchSize: maxBatchSize,
+		events:       make([]common.MapStr, 0, maxBatchSize),
+		pending:      nil,
+	}
+
+	ws.wg.Add(1)
+	go b.run()
+	return b
+}
+
+func (b *bulkWorker) send(m message) {
+	b.queue <- m
+}
+
+func (b *bulkWorker) run() {
+	defer b.shutdown()
+
+	for {
+		select {
+		case <-b.ws.done:
+			return
+		case m := <-b.queue:
+			fmt.Printf("received message: %v", m)
+
+			if m.event != nil { // single event
+				b.onEvent(m.signal, m.event)
+			} else { // batch of events
+				b.onEvents(m.signal, m.events)
+			}
+
+			// buffer full?
+			if len(b.events) == cap(b.events) {
+				b.publish()
+			}
+		case <-b.flushTicker.C:
+			logp.Debug("publish", "flush tick")
+			b.publish()
+		}
+	}
+}
+
+func (b *bulkWorker) onEvent(signal outputs.Signaler, event common.MapStr) {
+	b.events = append(b.events, event)
+	if signal != nil {
+		b.pending = append(b.pending, signal)
+	}
+}
+
+func (b *bulkWorker) onEvents(signal outputs.Signaler, events []common.MapStr) {
+	for len(events) > 0 {
+		// split up bulk to match required bulk sizes.
+		// If input events have been split up bufferFull will be set and
+		// bulk request will be published.
+		bufferFull := false
+		spaceLeft := cap(b.events) - len(b.events)
+		consume := len(events)
+		if spaceLeft < consume {
+			bufferFull = true
+			consume = spaceLeft
+			if signal != nil {
+				// creating cascading signaler chain for
+				// subset of events being send
+				signal = outputs.NewSplitSignaler(signal, 2)
+			}
+		}
+
+		// buffer events
+		b.events = append(b.events, events[:consume]...)
+		events = events[consume:]
+		if signal != nil {
+			b.pending = append(b.pending, signal)
+		}
+
+		if bufferFull {
+			b.publish()
+		}
+	}
+}
+
+func (b *bulkWorker) publish() {
+	b.send(message{
+		signal: outputs.NewCompositeSignaler(b.pending...),
+		events: b.events,
+	})
+
+	b.pending = nil
+	b.events = make([]common.MapStr, 0, b.maxBatchSize)
+}
+
+func (b *bulkWorker) shutdown() {
+	b.flushTicker.Stop()
+	stopQueue(b.queue)
+	b.ws.wg.Done()
+}

--- a/publisher/client.go
+++ b/publisher/client.go
@@ -1,0 +1,71 @@
+package publisher
+
+import "github.com/elastic/libbeat/common"
+
+// Client is used by beats to publish new events.
+type Client interface {
+	// PublishEvent publishes one event with given options. If Confirm option is set,
+	// PublishEvent will block until output plugins report success or failure state
+	// being returned by this method.
+	PublishEvent(event common.MapStr, opts ...ClientOption) bool
+
+	// PublishEvents publishes multiple events with given options. If Confirm
+	// option is set, PublishEvent will block until output plugins report
+	// success or failure state being returned by this method.
+	PublishEvents(event []common.MapStr, opts ...ClientOption) bool
+}
+
+// ChanClient will forward all published events one by one to the given channel
+type ChanClient struct {
+	Channel chan common.MapStr
+}
+
+type client struct {
+	publisher *PublisherType
+}
+
+type publishOptions struct {
+	confirm bool
+}
+
+// ClientOption allows API users to set additional options when publishing events.
+type ClientOption func(option *publishOptions)
+
+// Confirm option will block the event publisher until event has been send and ACKed
+// by output plugin or fail is reported.
+func Confirm(options *publishOptions) {
+	options.confirm = true
+}
+
+func (c *client) PublishEvent(event common.MapStr, opts ...ClientOption) bool {
+	return c.getClient(opts).PublishEvent(event)
+}
+
+func (c *client) PublishEvents(events []common.MapStr, opts ...ClientOption) bool {
+	return c.getClient(opts).PublishEvents(events)
+}
+
+func (c *client) getClient(opts []ClientOption) eventPublisher {
+	debug("send event")
+	options := publishOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if options.confirm {
+		return c.publisher.syncPublisher.client()
+	}
+	return c.publisher.asyncPublisher.client()
+}
+
+func (c ChanClient) PublishEvent(event common.MapStr, opts ...ClientOption) bool {
+	c.Channel <- event
+	return true
+}
+
+func (c ChanClient) PublishEvents(events []common.MapStr, opts ...ClientOption) bool {
+	for _, event := range events {
+		c.Channel <- event
+	}
+	return true
+}

--- a/publisher/client_test.go
+++ b/publisher/client_test.go
@@ -1,0 +1,16 @@
+package publisher
+
+import "github.com/elastic/libbeat/common"
+
+type nilClient struct{}
+
+// NilClient will ignore all events being published
+var NilClient Client = nilClient{}
+
+func (c nilClient) PublishEvent(event common.MapStr, opts ...ClientOption) bool {
+	return true
+}
+
+func (c nilClient) PublishEvents(events []common.MapStr, opts ...ClientOption) bool {
+	return true
+}

--- a/publisher/output.go
+++ b/publisher/output.go
@@ -1,0 +1,42 @@
+package publisher
+
+import (
+	"time"
+
+	"github.com/elastic/libbeat/outputs"
+)
+
+type outputWorker struct {
+	out    outputs.BulkOutputer
+	config outputs.MothershipConfig
+	worker *messageWorker
+}
+
+func newOutputWorker(
+	config outputs.MothershipConfig,
+	out outputs.Outputer,
+	ws *workerSignal,
+	hwm int,
+) *outputWorker {
+	o := &outputWorker{out: outputs.CastBulkOutputer(out)}
+	o.worker = newMessageWorker(ws, hwm, o)
+	return o
+}
+
+func (o *outputWorker) publish(m message) {
+	o.worker.queue <- m
+}
+
+func (o *outputWorker) onMessage(m message) {
+	if m.event != nil {
+		o.out.PublishEvent(m.signal, m.event["ts"].(time.Time), m.event)
+	} else {
+		if len(m.events) == 0 {
+			outputs.SignalCompleted(m.signal)
+			return
+		}
+
+		ts := m.events[0]["ts"].(time.Time)
+		o.out.BulkPublish(m.signal, ts, m.events)
+	}
+}

--- a/publisher/output.go
+++ b/publisher/output.go
@@ -3,13 +3,14 @@ package publisher
 import (
 	"time"
 
+	"github.com/elastic/libbeat/common"
 	"github.com/elastic/libbeat/outputs"
 )
 
 type outputWorker struct {
+	messageWorker
 	out    outputs.BulkOutputer
 	config outputs.MothershipConfig
-	worker *messageWorker
 }
 
 func newOutputWorker(
@@ -18,25 +19,28 @@ func newOutputWorker(
 	ws *workerSignal,
 	hwm int,
 ) *outputWorker {
-	o := &outputWorker{out: outputs.CastBulkOutputer(out)}
-	o.worker = newMessageWorker(ws, hwm, o)
+	o := &outputWorker{out: outputs.CastBulkOutputer(out), config: config}
+	o.messageWorker.init(ws, hwm, o)
 	return o
 }
 
-func (o *outputWorker) publish(m message) {
-	o.worker.queue <- m
-}
+func (o *outputWorker) onStop() {}
 
 func (o *outputWorker) onMessage(m message) {
+
 	if m.event != nil {
-		o.out.PublishEvent(m.signal, m.event["ts"].(time.Time), m.event)
+		debug("output worker: publish single event")
+		ts := time.Time(m.event["timestamp"].(common.Time))
+		_ = o.out.PublishEvent(m.signal, ts, m.event)
 	} else {
 		if len(m.events) == 0 {
+			debug("output worker: no events to publish")
 			outputs.SignalCompleted(m.signal)
 			return
 		}
 
-		ts := m.events[0]["ts"].(time.Time)
-		o.out.BulkPublish(m.signal, ts, m.events)
+		debug("output worker: publish %v events", len(m.events))
+		ts := time.Time(m.events[0]["timestamp"].(common.Time))
+		_ = o.out.BulkPublish(m.signal, ts, m.events)
 	}
 }

--- a/publisher/preprocess.go
+++ b/publisher/preprocess.go
@@ -21,6 +21,8 @@ func newPreprocessor(p *PublisherType, h messageHandler) *preprocessor {
 	}
 }
 
+func (p *preprocessor) onStop() { p.handler.onStop() }
+
 func (p *preprocessor) onMessage(m message) {
 	publisher := p.pub
 	single := false

--- a/publisher/preprocess.go
+++ b/publisher/preprocess.go
@@ -1,0 +1,172 @@
+package publisher
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/elastic/libbeat/common"
+	"github.com/elastic/libbeat/logp"
+	"github.com/elastic/libbeat/outputs"
+)
+
+type preprocessor struct {
+	handler messageHandler
+	pub     *PublisherType
+}
+
+func newPreprocessor(p *PublisherType, h messageHandler) *preprocessor {
+	return &preprocessor{
+		handler: h,
+		pub:     p,
+	}
+}
+
+func (p *preprocessor) onMessage(m message) {
+	publisher := p.pub
+	single := false
+	events := m.events
+	if events == nil {
+		single = true
+		events = []common.MapStr{m.event}
+	}
+
+	var ignore []int // indices of events to be removed from events
+
+	debug("preprocessor")
+
+	for i, event := range events {
+		// validate some required field
+		if err := filterEvent(event); err != nil {
+			logp.Err("Publishing event failed: %v", err)
+			ignore = append(ignore, i)
+			continue
+		}
+
+		// update address and geo-ip information. Ignore event
+		// if address is invalid or event is found to be a duplicate
+		ok := updateEventAddresses(publisher, event)
+		if !ok {
+			ignore = append(ignore, i)
+			continue
+		}
+
+		// add additional meta data
+		event["shipper"] = publisher.name
+		if len(publisher.tags) > 0 {
+			event["tags"] = publisher.tags
+		}
+
+		if logp.IsDebug("publish") {
+			PrintPublishEvent(event)
+		}
+	}
+
+	// return if no event is left
+	if len(ignore) == len(events) {
+		debug("no event left, complete send")
+		outputs.SignalCompleted(m.signal)
+		return
+	}
+
+	// remove invalid events.
+	// TODO: is order important? Removal can be turned into O(len(ignore)) by
+	//       copying last element into idx and doing
+	//       events=events[:len(events)-len(ignore)] afterwards
+	// Alternatively filtering could be implemented like:
+	//   https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	for i := len(ignore) - 1; i >= 0; i-- {
+		idx := ignore[i]
+		debug("remove event[%v]", idx)
+		events = append(events[:idx], events[idx+1:]...)
+	}
+
+	if publisher.disabled {
+		debug("publisher disabled")
+		outputs.SignalCompleted(m.signal)
+		return
+	}
+
+	debug("preprocessor forward")
+	if single {
+		p.handler.onMessage(message{signal: m.signal, event: events[0]})
+	} else {
+		p.handler.onMessage(message{signal: m.signal, events: events})
+	}
+}
+
+// filterEvent validates an event for common required fields with types.
+// If event is to be filtered out the reason is returned as error.
+func filterEvent(event common.MapStr) error {
+	_, ok := event["timestamp"].(common.Time)
+	if !ok {
+		return errors.New("Missing 'timestamp' field from event")
+	}
+
+	err := event.EnsureCountField()
+	if err != nil {
+		return err
+	}
+
+	t, ok := event["type"]
+	if !ok {
+		return errors.New("Missing 'type' field from event.")
+	}
+
+	_, ok = t.(string)
+	if !ok {
+		return errors.New("Invalid 'type' field from event.")
+	}
+
+	return nil
+}
+
+func updateEventAddresses(publisher *PublisherType, event common.MapStr) bool {
+	var srcServer, dstServer string
+	src, ok := event["src"].(*common.Endpoint)
+	if ok {
+		srcServer = publisher.GetServerName(src.Ip)
+		event["client_ip"] = src.Ip
+		event["client_port"] = src.Port
+		event["client_proc"] = src.Proc
+		event["client_server"] = srcServer
+		delete(event, "src")
+	}
+	dst, ok := event["dst"].(*common.Endpoint)
+	if ok {
+		dstServer = publisher.GetServerName(dst.Ip)
+		event["ip"] = dst.Ip
+		event["port"] = dst.Port
+		event["proc"] = dst.Proc
+		event["server"] = dstServer
+		delete(event, "dst")
+	}
+
+	if publisher.IgnoreOutgoing && dstServer != "" &&
+		dstServer != publisher.name {
+		// duplicated transaction -> ignore it
+		debug("Ignore duplicated transaction on %s: %s -> %s",
+			publisher.name, srcServer, dstServer)
+		return false
+	}
+
+	if publisher.GeoLite != nil {
+		realIP, exists := event["real_ip"]
+		if exists && len(realIP.(string)) > 0 {
+			loc := publisher.GeoLite.GetLocationByIP(realIP.(string))
+			if loc != nil && loc.Latitude != 0 && loc.Longitude != 0 {
+				loc := fmt.Sprintf("%f, %f", loc.Latitude, loc.Longitude)
+				event["client_location"] = loc
+			}
+		} else {
+			if len(srcServer) == 0 && src != nil { // only for external IP addresses
+				loc := publisher.GeoLite.GetLocationByIP(src.Ip)
+				if loc != nil && loc.Latitude != 0 && loc.Longitude != 0 {
+					loc := fmt.Sprintf("%f, %f", loc.Latitude, loc.Longitude)
+					event["client_location"] = loc
+				}
+			}
+		}
+	}
+
+	return true
+}

--- a/publisher/publish.go
+++ b/publisher/publish.go
@@ -25,7 +25,7 @@ var publishDisabled *bool
 var debug = logp.MakeDebug("publish")
 
 // EventPublisher provides the interface for beats to publish events.
-type EventPublisher interface {
+type eventPublisher interface {
 	PublishEvent(event common.MapStr) bool
 	PublishEvents(events []common.MapStr) bool
 }
@@ -107,12 +107,8 @@ func (publisher *PublisherType) GetServerName(ip string) string {
 	return ""
 }
 
-func (publisher *PublisherType) Client() EventPublisher {
-	return publisher.asyncPublisher.client()
-}
-
-func (publisher *PublisherType) SyncClient() EventPublisher {
-	return publisher.syncPublisher.client()
+func (publisher *PublisherType) Client() Client {
+	return &client{publisher}
 }
 
 func (publisher *PublisherType) UpdateTopologyPeriodically() {

--- a/publisher/sync.go
+++ b/publisher/sync.go
@@ -22,7 +22,7 @@ func newSyncPublisher(pub *PublisherType) *syncPublisher {
 	return s
 }
 
-func (p *syncPublisher) client() EventPublisher {
+func (p *syncPublisher) client() eventPublisher {
 	return syncClient(p.send)
 }
 

--- a/publisher/sync.go
+++ b/publisher/sync.go
@@ -26,11 +26,13 @@ func (p *syncPublisher) client() EventPublisher {
 	return syncClient(p.send)
 }
 
+func (p *syncPublisher) onStop() {}
+
 func (p *syncPublisher) onMessage(m message) {
 	signal := outputs.NewSplitSignaler(m.signal, len(p.pub.Output))
 	m.signal = signal
 	for _, o := range p.pub.Output {
-		o.publish(m)
+		o.send(m)
 	}
 }
 

--- a/publisher/sync.go
+++ b/publisher/sync.go
@@ -1,0 +1,55 @@
+package publisher
+
+import (
+	"github.com/elastic/libbeat/common"
+	"github.com/elastic/libbeat/outputs"
+)
+
+type syncPublisher struct {
+	messageWorker
+	pub *PublisherType
+}
+
+type syncClient func(message)
+
+type syncSignal struct {
+	ch chan bool
+}
+
+func newSyncPublisher(pub *PublisherType) *syncPublisher {
+	s := &syncPublisher{pub: pub}
+	s.messageWorker.init(&pub.wsPublisher, 1000, newPreprocessor(pub, s))
+	return s
+}
+
+func (p *syncPublisher) client() EventPublisher {
+	return syncClient(p.send)
+}
+
+func (p *syncPublisher) onMessage(m message) {
+	signal := outputs.NewSplitSignaler(m.signal, len(p.pub.Output))
+	m.signal = signal
+	for _, o := range p.pub.Output {
+		o.publish(m)
+	}
+}
+
+func (c syncClient) PublishEvent(event common.MapStr) bool {
+	return c.send(message{event: event})
+}
+
+func (c syncClient) PublishEvents(events []common.MapStr) bool {
+	return c.send(message{events: events})
+}
+
+func (c syncClient) send(m message) bool {
+	sync := newSyncSignal()
+	m.signal = sync
+	c(m)
+	return sync.wait()
+}
+
+func newSyncSignal() *syncSignal { return &syncSignal{make(chan bool)} }
+func (s *syncSignal) wait() bool { return <-s.ch }
+func (s *syncSignal) Completed() { s.ch <- true }
+func (s *syncSignal) Failed()    { s.ch <- false }

--- a/publisher/worker.go
+++ b/publisher/worker.go
@@ -1,0 +1,75 @@
+package publisher
+
+import (
+	"sync"
+
+	"github.com/elastic/libbeat/common"
+	"github.com/elastic/libbeat/outputs"
+)
+
+type messageWorker struct {
+	queue   chan message
+	ws      *workerSignal
+	handler messageHandler
+}
+
+type message struct {
+	signal outputs.Signaler
+	event  common.MapStr
+	events []common.MapStr
+}
+
+type workerSignal struct {
+	done chan struct{}
+	wg   sync.WaitGroup
+}
+
+type messageHandler interface {
+	onMessage(m message)
+}
+
+func newMessageWorker(ws *workerSignal, hwm int, h messageHandler) *messageWorker {
+	p := &messageWorker{}
+	p.init(ws, hwm, h)
+	return p
+}
+
+func (p *messageWorker) init(ws *workerSignal, hwm int, h messageHandler) {
+	p.queue = make(chan message, hwm)
+	p.ws = ws
+	p.handler = h
+	ws.wg.Add(1)
+	go p.run()
+}
+
+func (p *messageWorker) run() {
+	defer func() {
+		close(p.queue)
+		for msg := range p.queue { // clear queue
+			outputs.SignalFailed(msg.signal)
+		}
+		p.ws.wg.Done()
+	}()
+
+	for {
+		select {
+		case m := <-p.queue:
+			p.handler.onMessage(m)
+		case <-p.ws.done:
+			return
+		}
+	}
+}
+
+func (p *messageWorker) send(m message) {
+	p.queue <- m
+}
+
+func (ws *workerSignal) stop() {
+	close(ws.done)
+	ws.wg.Wait()
+}
+
+func (ws *workerSignal) Init() {
+	ws.done = make(chan struct{})
+}


### PR DESCRIPTION
Define outputs.Transactioner interface to signal success/failure of output/publish operations. Beats must pass nil if they are not interested in any status output.

All output plugins have been modified to signal transactioners after doing IO. If publisher has multiple output plugins configured and only one interface fails, the complete transaction will be marked as Failed().

depends on #56 and #68. 