### PR TITLE
Added a Cache data structure to libbeat.

### DIFF
--- a/common/cache.go
+++ b/common/cache.go
@@ -1,0 +1,229 @@
+package common
+
+import (
+	"sync"
+	"time"
+)
+
+// Key type used in the cache.
+type Key interface{}
+
+// Value type held in the cache. Cannot be nil.
+type Value interface{}
+
+// RemovalListener is the callback function type that can be registered with
+// the cache to receive notification of the removal of expired elements.
+type RemovalListener func(k Key, v Value)
+
+// Clock is the function type used to get the current time.
+type clock func() time.Time
+
+// An element stored in the cache.
+type element struct {
+	expiration time.Time
+	value      Value
+}
+
+// IsExpired returns true if the element is expired (current time is greater
+// than the expiration time).
+func (e *element) IsExpired(now time.Time) bool {
+	return now.After(e.expiration)
+}
+
+// UpdateLastAccessTime updates the expiration time of the element. This
+// should be called each time the element is accessed.
+func (e *element) UpdateLastAccessTime(now time.Time, expiration time.Duration) {
+	e.expiration = now.Add(expiration)
+}
+
+// Cache is a semi-persistent mapping of keys to values. Elements added to the
+// cache are store until they are explicitly deleted or are expired due time-
+// based eviction based on last access time.
+//
+// Expired elements are not visible through classes methods, but they do remain
+// stored in the cache until CleanUp() is invoked. Therefore CleanUp() must be
+// invoked periodically to prevent the cache from becoming a memory leak. If
+// you want to start a goroutine to perform periodic clean-up then see
+// StartJanitor().
+//
+// Cache does not support storing nil values. Any attempt to put nil into
+// the cache will cause a panic.
+type Cache struct {
+	sync.RWMutex
+	timeout     time.Duration    // Length of time before cache elements expire.
+	elements    map[Key]*element // Data stored by the cache.
+	clock       clock            // Function used to get the current time.
+	listener    RemovalListener  // Callback listen to notify of evictions.
+	janitorQuit chan struct{}    // Closing this channel stop the janitor.
+}
+
+// NewCache creates and returns a new Cache. d is the length of time after last
+// access that cache elements expire. initialSize is the initial allocation size
+// used for the Cache's underlying map.
+func NewCache(d time.Duration, initialSize int) *Cache {
+	return newCache(d, initialSize, nil, time.Now)
+}
+
+// NewCacheWithRemovalListener creates and returns a new Cache and register a
+// RemovalListener callback function. d is the length of time after last access
+// that cache elements expire. initialSize is the initial allocation size used
+// for the Cache's underlying map. l is the callback function that will be
+// invoked when cache elements are removed from the map on CleanUp.
+func NewCacheWithRemovalListener(d time.Duration, initialSize int, l RemovalListener) *Cache {
+	return newCache(d, initialSize, l, time.Now)
+}
+
+func newCache(d time.Duration, initialSize int, l RemovalListener, t clock) *Cache {
+	return &Cache{
+		timeout:  d,
+		elements: make(map[Key]*element, initialSize),
+		listener: l,
+		clock:    t,
+	}
+}
+
+// PutIfAbsent writes the given key and value to the cache only if the key is
+// absent from the cache. Nil is returned if the key-value pair were written,
+// otherwise the old value is returned.
+func (c *Cache) PutIfAbsent(k Key, v Value) Value {
+	c.Lock()
+	defer c.Unlock()
+	oldValue, exists := c.get(k)
+	if exists {
+		return oldValue
+	}
+
+	c.put(k, v)
+	return nil
+}
+
+// Put writes the given key and value to the map replacing any existing value
+// if it exists. The previous value associated with the key returned or nil
+// if the key was not present.
+func (c *Cache) Put(k Key, v Value) Value {
+	c.Lock()
+	defer c.Unlock()
+	oldValue, _ := c.get(k)
+	c.put(k, v)
+	return oldValue
+}
+
+// Replace overwrites the value for a key only if the key exists. The old
+// value is returned if the value is updated, otherwise nil is returned.
+func (c *Cache) Replace(k Key, v Value) Value {
+	c.Lock()
+	defer c.Unlock()
+	oldValue, exists := c.get(k)
+	if !exists {
+		return nil
+	}
+
+	c.put(k, v)
+	return oldValue
+}
+
+// Get the current value associated with a key or nil if the key is not
+// present. The last access time of the element is updated.
+func (c *Cache) Get(k Key) Value {
+	c.RLock()
+	defer c.RUnlock()
+	v, _ := c.get(k)
+	return v
+}
+
+// Delete a key from the map and return the value or nil if the key does
+// not exist. The RemovalListener is not notified for explicit deletions.
+func (c *Cache) Delete(k Key) Value {
+	c.Lock()
+	defer c.Unlock()
+	v, _ := c.get(k)
+	delete(c.elements, k)
+	return v
+}
+
+// CleanUp performs maintenance on the cache by removing expired elements from
+// the cache. If a RemoveListener is registered it will be invoked for each
+// element that is removed during this clean up operation. The RemovalListener
+// is invoked on the caller's goroutine.
+func (c *Cache) CleanUp() int {
+	c.Lock()
+	defer c.Unlock()
+	count := 0
+	for k, v := range c.elements {
+		if v.IsExpired(c.clock()) {
+			delete(c.elements, k)
+			count++
+			if c.listener != nil {
+				c.listener(k, v.value)
+			}
+		}
+	}
+	return count
+}
+
+// Entries returns a copy of the non-expired elements in the cache.
+func (c *Cache) Entries() map[Key]Value {
+	c.RLock()
+	defer c.RUnlock()
+	copy := make(map[Key]Value, len(c.elements))
+	for k, v := range c.elements {
+		if !v.IsExpired(c.clock()) {
+			copy[k] = v.value
+		}
+	}
+	return copy
+}
+
+// Size returns the number of elements in the cache. The number includes both
+// active elements and expired elements that have not been cleaned up.
+func (c *Cache) Size() int {
+	c.RLock()
+	defer c.RUnlock()
+	return len(c.elements)
+}
+
+// StartJanitor starts a goroutine that will periodically invoke the cache's
+// CleanUp() method.
+func (c *Cache) StartJanitor(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	c.janitorQuit = make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				c.CleanUp()
+			case <-c.janitorQuit:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+// StopJanitor stops the goroutine created by StartJanitor.
+func (c *Cache) StopJanitor() {
+	close(c.janitorQuit)
+}
+
+// get returns the non-expired values from the cache.
+func (c *Cache) get(k Key) (Value, bool) {
+	elem, exists := c.elements[k]
+	now := c.clock()
+	if exists && !elem.IsExpired(now) {
+		elem.UpdateLastAccessTime(now, c.timeout)
+		return elem.value, true
+	}
+	return nil, false
+}
+
+// put writes a key-value to the cache replacing any existing mapping.
+func (c *Cache) put(k Key, v Value) {
+	if v == nil {
+		panic("Cache does not support storing nil values.")
+	}
+
+	c.elements[k] = &element{
+		expiration: c.clock().Add(c.timeout),
+		value:      v,
+	}
+}

--- a/common/cache_test.go
+++ b/common/cache_test.go
@@ -1,0 +1,167 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	Timeout    time.Duration = 1 * time.Minute
+	InitalSize int           = 10
+)
+
+const (
+	alphaKey   = "alphaKey"
+	alphaValue = "a"
+	bravoKey   = "bravoKey"
+	bravoValue = "b"
+)
+
+// Current time as simulated by the fakeClock function.
+var (
+	currentTime time.Time
+	fakeClock   clock = func() time.Time {
+		return currentTime
+	}
+)
+
+// RemovalListener callback.
+var (
+	callbackKey     Key
+	callbackValue   Value
+	removalListener RemovalListener = func(k Key, v Value) {
+		callbackKey = k
+		callbackValue = v
+	}
+)
+
+// Test that the removal listener is invoked with the expired key/value.
+func TestExpireWithRemovalListener(t *testing.T) {
+	callbackKey = nil
+	callbackValue = nil
+	c := newCache(Timeout, InitalSize, removalListener, fakeClock)
+	c.Put(alphaKey, alphaValue)
+	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
+	assert.Equal(t, 1, c.CleanUp())
+	assert.Equal(t, alphaKey, callbackKey)
+	assert.Equal(t, alphaValue, callbackValue)
+}
+
+// Test that the number of removed elements is returned by Expire.
+func TestExpireWithoutRemovalListener(t *testing.T) {
+	c := newCache(Timeout, InitalSize, nil, fakeClock)
+	c.Put(alphaKey, alphaValue)
+	c.Put(bravoKey, bravoValue)
+	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
+	assert.Equal(t, 2, c.CleanUp())
+}
+
+func TestPutIfAbsent(t *testing.T) {
+	c := newCache(Timeout, InitalSize, nil, fakeClock)
+	oldValue := c.PutIfAbsent(alphaKey, alphaValue)
+	assert.Nil(t, oldValue)
+	oldValue = c.PutIfAbsent(alphaKey, bravoValue)
+	assert.Equal(t, alphaValue, oldValue)
+}
+
+func TestPut(t *testing.T) {
+	c := newCache(Timeout, InitalSize, nil, fakeClock)
+	oldValue := c.Put(alphaKey, alphaValue)
+	assert.Nil(t, oldValue)
+	oldValue = c.Put(bravoKey, bravoValue)
+	assert.Nil(t, oldValue)
+
+	oldValue = c.Put(alphaKey, bravoValue)
+	assert.Equal(t, alphaValue, oldValue)
+	oldValue = c.Put(bravoKey, alphaValue)
+	assert.Equal(t, bravoValue, oldValue)
+}
+
+func TestReplace(t *testing.T) {
+	c := newCache(Timeout, InitalSize, nil, fakeClock)
+
+	// Nil is returned when the value does not exist and no element is added.
+	assert.Nil(t, c.Replace(alphaKey, alphaValue))
+	assert.Equal(t, 0, c.Size())
+
+	// alphaKey is replaced with the new value.
+	assert.Nil(t, c.Put(alphaKey, alphaValue))
+	assert.Equal(t, alphaValue, c.Replace(alphaKey, bravoValue))
+	assert.Equal(t, 1, c.Size())
+}
+
+func TestGetUpdatesLastAccessTime(t *testing.T) {
+	c := newCache(Timeout, InitalSize, nil, fakeClock)
+	c.Put(alphaKey, alphaValue)
+
+	currentTime = currentTime.Add(Timeout / 2)
+	assert.Equal(t, alphaValue, c.Get(alphaKey))
+	currentTime = currentTime.Add(Timeout / 2)
+	assert.Equal(t, alphaValue, c.Get(alphaKey))
+}
+
+func TestDeleteNonExistentKey(t *testing.T) {
+	c := newCache(Timeout, InitalSize, nil, fakeClock)
+	assert.Nil(t, c.Delete(alphaKey))
+}
+
+func TestDeleteExistingKey(t *testing.T) {
+	c := newCache(Timeout, InitalSize, nil, fakeClock)
+	c.Put(alphaKey, alphaValue)
+	assert.Equal(t, alphaValue, c.Delete(alphaKey))
+}
+
+func TestDeleteExpiredKey(t *testing.T) {
+	c := newCache(Timeout, InitalSize, nil, fakeClock)
+	c.Put(alphaKey, alphaValue)
+	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
+	assert.Nil(t, c.Delete(alphaKey))
+}
+
+// Test that Entries returns the non-expired map entries.
+func TestEntries(t *testing.T) {
+	c := newCache(Timeout, InitalSize, nil, fakeClock)
+	c.Put(alphaKey, alphaValue)
+	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
+	c.Put(bravoKey, bravoValue)
+	m := c.Entries()
+	assert.Equal(t, 1, len(m))
+	assert.Equal(t, bravoValue, m[bravoKey])
+}
+
+// Test that Size returns a count of both expired and non-expired elements.
+func TestSize(t *testing.T) {
+	c := newCache(Timeout, InitalSize, nil, fakeClock)
+	c.Put(alphaKey, alphaValue)
+	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
+	c.Put(bravoKey, bravoValue)
+	assert.Equal(t, 2, c.Size())
+}
+
+func TestGetExpiredValue(t *testing.T) {
+	c := newCache(Timeout, InitalSize, nil, fakeClock)
+	c.Put(alphaKey, alphaValue)
+	v := c.Get(alphaKey)
+	assert.Equal(t, alphaValue, v)
+
+	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
+	v = c.Get(alphaKey)
+	assert.Nil(t, v)
+}
+
+// Test that the janitor invokes CleanUp on the cache and that the
+// RemovalListener is invoked during clean up.
+func TestJanitor(t *testing.T) {
+	keyChan := make(chan Key)
+	c := newCache(Timeout, InitalSize, func(k Key, v Value) {
+		keyChan <- k
+	}, fakeClock)
+	c.Put(alphaKey, alphaValue)
+	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
+	c.StartJanitor(time.Millisecond)
+	key := <-keyChan
+	c.StopJanitor()
+	assert.Equal(t, alphaKey, key)
+}


### PR DESCRIPTION
This pull request adds a cache data structure to libbeat. The Cache will be used to address some concurrency-safety issues in Packetbeat. 

Packetbeat will be updated to store the streams and transactions of most of the protocol plugins in the Cache. This will address the immediate needs for elastic/packetbeat#203 but the final solution will be to refactor Packetbeat to not require locking. 

Also by using this cache, Packetbeat will not need to create a new `time.Timer` for every transaction. Instead, a single goroutine can be used to periodically clean up expired entries in an instance of the Cache.