### PR TITLE
Enhancing testsuite build target to make it a bit more reliable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,20 @@ RUN go get \
 	golang.org/x/tools/cmd/cover \
 	golang.org/x/tools/cmd/vet
 
-WORKDIR /go/src/github.com/elastic/libbeat
-# Setup work environment
-RUN mkdir -p /go/src/github.com/elastic/libbeat
+COPY docker-entrypoint.sh /entrypoint.sh
 
+# Setup work environment
+ENV LIBBEAT_PATH /go/src/github.com/elastic/libbeat
+RUN mkdir -p $LIBBEAT_PATH
+WORKDIR $LIBBEAT_PATH
+
+# Create a copy of the respository inside the container.
 COPY . /go/src/github.com/elastic/libbeat
 
+# It is expected that libbeat from the host is mounted
+# within the container at the WORKDIR location.
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Build libbeat inside of the container so that it is ready
+# for testing.
 RUN make

--- a/Makefile
+++ b/Makefile
@@ -30,25 +30,25 @@ autotest:
 .PHONY: testlong
 testlong:
 	go vet ./...
-	make cover
+	make coverage
 
 .PHONY: benchmark
 benchmark:
 	go test -short -bench=. ./...
 
-.PHONY: cover
-cover:
+.PHONY: coverage
+coverage:
 	# gotestcover is needed to fetch coverage for multiple packages
 	go get github.com/pierrre/gotestcover
 	GOPATH=$(shell $(GODEP) path):$(GOPATH) $(GOPATH)/bin/gotestcover -coverprofile=profile.cov -covermode=count github.com/elastic/libbeat/...
-	mkdir -p cover
-	$(GODEP) go tool cover -html=profile.cov -o cover/coverage.html
+	mkdir -p coverage
+	$(GODEP) go tool cover -html=profile.cov -o coverage/coverage.html
 
 .PHONY: clean
 clean:
 	make gofmt
 	-rm profile.cov
-	-rm -r cover
+	-rm -r coverage
 
 
 # Builds the environment to test libbeat
@@ -60,23 +60,22 @@ build-image:
 # Runs the environment so the redis and elasticsearch can also be used for local development
 # To use it for running the test, set ES_HOST and REDIS_HOST environment variable to the ip of your docker-machine.
 .PHONY: start-environment
-start-environment: build-image
-	docker-compose up -d
+start-environment: stop-environment
+	docker-compose up -d redis elasticsearch
 	
 .PHONY: stop-environment
 stop-environment:
-	docker-compose stop
-	docker-compose rm -f
+	-docker-compose stop
+	-docker-compose rm -f
+	-docker ps -a  | grep libbeat | grep Exited | awk '{print $$1}' | xargs docker rm
 
 # Runs the full test suite and puts out the result. This can be run on any docker-machine (local, remote)
 .PHONY: testsuite
 testsuite: build-image
 	docker-compose run libbeat make testlong
 	# Copy coverage file back to host
-	mkdir -p cover
-	docker cp libbeat_libbeat_run_1:/go/src/github.com/elastic/libbeat/profile.cov $(shell pwd)/profile.cov
-	docker cp libbeat_libbeat_run_1:/go/src/github.com/elastic/libbeat/cover/coverage.html $(shell pwd)/cover/coverage.html
-	make stop-environment
+	docker cp libbeat_libbeat_run_1:/go/src/github.com/elastic/libbeat/profile.cov $(shell pwd)/
+	docker cp libbeat_libbeat_run_1:/go/src/github.com/elastic/libbeat/coverage/coverage.html $(shell pwd)/coverage/
 
 # Sets up docker-compose locally for jenkins so no global installation is needed
 .PHONY: testsuite

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+# This script is the entrypoint to the libbeat Docker container. This will
+# verify that the Elasticsearch and Redis environment variables are set
+# and that Elasticsearch is running before executing the command provided
+# to the docker container.
+
+# Read parameters from the environment and validate them.
+readParams() {
+  if [ -z "$ES_HOST" ]; then
+    echo >&2 'Error: missing required ES_HOST environment variable'
+    echo >&2 '  Did you forget to -e ES_HOST=... ?'
+    exit 1
+  fi
+
+  if [ -z "$REDIS_HOST" ]; then
+    echo >&2 'Error: missing required REDIS_HOST environment variable'
+    echo >&2 '  Did you forget to -e REDIS_HOST=... ?'
+    exit 1
+  fi
+
+  # Use default ports if not specified.
+  : ${ES_PORT:=9200}
+  : ${REDIS_PORT:=6379}
+}
+
+# Wait for elasticsearch to start. It requires that the status be either
+# green or yellow.
+waitForElasticsearch() {
+  echo -n 'Waiting on elasticsearch to start.'
+  for ((i=1;i<=30;i++))
+  do
+    health=$(curl --silent "http://${ES_HOST}:${ES_PORT}/_cat/health" | awk '{print $4}')
+    if [[ "$health" == "green" ]] || [[ "$health" == "yellow" ]]
+    then
+      echo
+      echo "Elasticsearch is ready!"
+      return 0
+    fi
+
+    ((i++))
+    echo -n '.'
+    sleep 1
+  done
+
+  echo
+  echo >&2 'Elasticsearch is not running or is not healthy.'
+  echo >&2 "Address: ${ES_HOST}:${ES_PORT}"
+  echo >&2 "$health"
+  exit 1
+}
+
+# Main
+readParams
+waitForElasticsearch
+exec "$@"


### PR DESCRIPTION
###### Changes
* ~~Fixes an issue with libbeat docker container caching the contents of the repository.~~
* The libbeat container now waits for elasticsearch to start before executing tests.
* ~~Exposing redis and elasticsearch ports on the docker-machine for local development purposes.~~
* Added clean-up command to ensure any stopped container is deleted prior to starting to ensure the libbeat container is predictably named which is required in order to copy coverage reports to host.
* Rename make target `cover` to `coverage`.

The Jenkins job for libbeat should be updated to remove the `sleep 10` and add an explicit `make stop-environment`. `make stop-environment` should be called irregardless of whether or not the build succeeds to ensure that the docker containers are stopped and removed.

##### Usage

###### Running Integration Tests inside Docker
This will start the elasticsearch and redis containers and then execute the integration tests inside an container.
```
make testsuite
```

You should stop the Elasticsearch and Redis containers when you are done with them.
```
make stop-environment
```

###### Running Integration Tests Locally
This method is more complicated but enables you to execute the integration tests from your machine rather than inside of a container.
```
# Verify that the active machine is what you expect.
docker-machine active
docker-compose pull
# Set the environment variables that are read by the tests.
export ES_HOST=$(docker-machine ip <name here>)
export ES_PORT=<choose an available port>
export REDIS_HOST=$(docker-machine ip <name here>)
export REDIS_PORT=<choose an available port>
# Start up containers and expose the ports on the docker machine.
docker run -d -p $ES_PORT:9200 --name libbeat_es elasticsearch
docker run -d -p $REDIS_PORT:6379 --name libbeat_redis redis
# Wait for the containers to boot then run integration tests.
make testlong
```

To stop the containers:
```
docker stop libbeat_es libbeat_redis
docker rm libbeat_es libbeat_redis
```

