### PR TITLE
Handle errors when the return type is error.

### DIFF
--- a/beat/beat.go
+++ b/beat/beat.go
@@ -68,18 +68,22 @@ func (beat *Beat) CommandLineSetup() {
 	}
 }
 
-// Inits the config file and reads the default config information into Beat.Config
-// This is Output, Logging and Shipper config params
+// LoadConfig inits the config file and reads the default config information
+// into Beat.Config. It exists the processes in case of errors.
 func (b *Beat) LoadConfig() {
 
 	err := cfgfile.Read(&b.Config, "")
-
 	if err != nil {
+		// logging not yet initialized, so using fmt.Printf
 		fmt.Printf("%v\n", err)
 		os.Exit(1)
 	}
 
-	logp.Init(b.Name, &b.Config.Logging)
+	err = logp.Init(b.Name, &b.Config.Logging)
+	if err != nil {
+		fmt.Printf("Error initializing logging: %v\n", err)
+		os.Exit(1)
+	}
 
 	logp.Debug("beat", "Initializing output plugins")
 
@@ -93,11 +97,16 @@ func (b *Beat) LoadConfig() {
 	logp.Debug("beat", "Init %s", b.Name)
 }
 
-// internal libbeat function that calls beater Run method
+// Run calls the beater Setup and Run methods. In case of errors
+// during the setup phase, it exits the process.
 func (b *Beat) Run() {
 
 	// Setup beater object
-	b.BT.Setup(b)
+	err := b.BT.Setup(b)
+	if err != nil {
+		logp.Critical("Setup returned an error: %v", err)
+		os.Exit(1)
+	}
 
 	// Up to here was the initialization, now about running
 	if cfgfile.IsTestConfig() {
@@ -112,17 +121,23 @@ func (b *Beat) Run() {
 	service.HandleSignals(b.BT.Stop)
 
 	// Run beater specific stuff
-	b.BT.Run(b)
+	err = b.BT.Run(b)
+	if err != nil {
+		logp.Critical("Run returned an error: %v", err)
+	}
 
 	service.Cleanup()
 
 	logp.Debug("beat", "Cleanup")
 
 	// Call beater cleanup function
-	b.BT.Cleanup(b)
+	err = b.BT.Cleanup(b)
+	if err != nil {
+		logp.Err("Cleanup returned an error: %v", err)
+	}
 }
 
-// Stops the beat and calls the beater Stop action
+// Stop calls the beater Stop action.
 func (beat *Beat) Stop() {
 	beat.BT.Stop()
 }


### PR DESCRIPTION
This does something with all errors that can be returned by the Beater
function. Something can mean exiting with error code 1 in case of issues
during setup, or just logging the error in other cases.

Part of the solution for #75.

Also edits some of the comments to use the godoc conventions.