### PR TITLE
Bug #79 tls config

### DIFF
--- a/outputs/elasticsearch/api.go
+++ b/outputs/elasticsearch/api.go
@@ -66,21 +66,21 @@ func NewElasticsearch(
 	var pool ConnectionPool
 	_ = pool.SetConnections(urls, username, password) // never errors
 
-	var transp *http.Transport
 	if tls != nil {
-		transp = &http.Transport{
-			TLSClientConfig: tls,
+		return &Elasticsearch{
+			connectionPool: pool,
+			client: &http.Client{
+				Transport: &http.Transport{TLSClientConfig: tls},
+			},
+			MaxRetries: defaultMaxRetries,
 		}
 	}
 
-	es := Elasticsearch{
+	return &Elasticsearch{
 		connectionPool: pool,
-		client: &http.Client{
-			Transport: transp,
-		},
-		MaxRetries: defaultMaxRetries,
+		client:         &http.Client{},
+		MaxRetries:     defaultMaxRetries,
 	}
-	return &es
 }
 
 // Encode parameters in url

--- a/outputs/elasticsearch/api_mock_test.go
+++ b/outputs/elasticsearch/api_mock_test.go
@@ -42,7 +42,7 @@ func TestOneHostSuccessResp(t *testing.T) {
 
 	server := ElasticsearchMock(200, expectedResp)
 
-	es := NewElasticsearch([]string{server.URL}, "", "")
+	es := NewElasticsearch([]string{server.URL}, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",
@@ -71,7 +71,7 @@ func TestOneHost500Resp(t *testing.T) {
 
 	server := ElasticsearchMock(http.StatusInternalServerError, []byte("Something wrong happened"))
 
-	es := NewElasticsearch([]string{server.URL}, "", "")
+	es := NewElasticsearch([]string{server.URL}, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",
@@ -101,7 +101,7 @@ func TestOneHost503Resp(t *testing.T) {
 
 	server := ElasticsearchMock(503, []byte("Something wrong happened"))
 
-	es := NewElasticsearch([]string{server.URL}, "", "")
+	es := NewElasticsearch([]string{server.URL}, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",
@@ -134,7 +134,7 @@ func TestMultipleHosts(t *testing.T) {
 	server2 := ElasticsearchMock(200, expectedResp)
 
 	logp.Debug("elasticsearch", "%s, %s", server1.URL, server2.URL)
-	es := NewElasticsearch([]string{server1.URL, server2.URL}, "", "")
+	es := NewElasticsearch([]string{server1.URL, server2.URL}, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",
@@ -165,7 +165,7 @@ func TestMultipleFailingHosts(t *testing.T) {
 	server2 := ElasticsearchMock(500, []byte("Something went wrong"))
 
 	logp.Debug("elasticsearch", "%s, %s", server1.URL, server2.URL)
-	es := NewElasticsearch([]string{server1.URL, server2.URL}, "", "")
+	es := NewElasticsearch([]string{server1.URL, server2.URL}, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",

--- a/outputs/elasticsearch/api_test.go
+++ b/outputs/elasticsearch/api_test.go
@@ -37,7 +37,7 @@ func GetTestingElasticsearch() *Elasticsearch {
 
 	var address = "http://" + GetEsHost() + ":" + GetEsPort()
 
-	return NewElasticsearch([]string{address}, "", "")
+	return NewElasticsearch([]string{address}, nil, "", "")
 }
 
 func GetValidQueryResult() QueryResult {

--- a/outputs/elasticsearch/bulkapi_mock_test.go
+++ b/outputs/elasticsearch/bulkapi_mock_test.go
@@ -40,7 +40,7 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 
 	server := ElasticsearchMock(200, expectedResp)
 
-	es := NewElasticsearch([]string{server.URL}, "", "")
+	es := NewElasticsearch([]string{server.URL}, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",
@@ -81,7 +81,7 @@ func TestOneHost500Resp_Bulk(t *testing.T) {
 
 	server := ElasticsearchMock(http.StatusInternalServerError, []byte("Something wrong happened"))
 
-	es := NewElasticsearch([]string{server.URL}, "", "")
+	es := NewElasticsearch([]string{server.URL}, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",
@@ -123,7 +123,7 @@ func TestOneHost503Resp_Bulk(t *testing.T) {
 
 	server := ElasticsearchMock(503, []byte("Something wrong happened"))
 
-	es := NewElasticsearch([]string{server.URL}, "", "")
+	es := NewElasticsearch([]string{server.URL}, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",
@@ -168,7 +168,7 @@ func TestMultipleHost_Bulk(t *testing.T) {
 	server1 := ElasticsearchMock(503, []byte("Somehting went wrong"))
 	server2 := ElasticsearchMock(200, expectedResp)
 
-	es := NewElasticsearch([]string{server1.URL, server2.URL}, "", "")
+	es := NewElasticsearch([]string{server1.URL, server2.URL}, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -73,7 +73,12 @@ func (out *elasticsearchOutput) Init(
 		urls = append(urls, url)
 	}
 
-	es := NewElasticsearch(urls, config.Username, config.Password)
+	tlsConfig, err := outputs.LoadTLSConfig(config)
+	if err != nil {
+		return err
+	}
+
+	es := NewElasticsearch(urls, tlsConfig, config.Username, config.Password)
 	out.Conn = es
 
 	if config.Index != "" {

--- a/outputs/lumberjack/lumberjack.go
+++ b/outputs/lumberjack/lumberjack.go
@@ -4,6 +4,7 @@ package lumberjack
 // output plugins
 
 import (
+	"crypto/tls"
 	"errors"
 	"time"
 
@@ -62,18 +63,15 @@ func (lj *lumberjack) init(
 	var clients []ProtocolClient
 	var err error
 	if useTLS {
-		var tlsConfig *tlsConfig
-		tlsConfig, err = loadTLSConfig(&TLSConfig{
-			Certificate: config.Certificate,
-			Key:         config.CertificateKey,
-			CAs:         config.CAs})
+		var tlsConfig *tls.Config
+		tlsConfig, err = outputs.LoadTLSConfig(config)
 		if err != nil {
 			return err
 		}
 
 		clients, err = makeClients(config, timeout,
 			func(host string) (TransportClient, error) {
-				return newTLSClient(host, *tlsConfig)
+				return newTLSClient(host, tlsConfig)
 			})
 	} else {
 		clients, err = makeClients(config, timeout,

--- a/outputs/lumberjack/transport.go
+++ b/outputs/lumberjack/transport.go
@@ -2,23 +2,12 @@ package lumberjack
 
 import (
 	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
-	"errors"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"time"
 
 	"github.com/elastic/libbeat/logp"
 )
-
-// TLSConfig lists certificate and key files to be loaded for TLS based connections.
-type TLSConfig struct {
-	Certificate string
-	Key         string
-	CAs         []string
-}
 
 // TransportClient interfaces adds (re-)connect support to net.Conn.
 type TransportClient interface {
@@ -35,36 +24,8 @@ type tcpClient struct {
 
 type tlsClient struct {
 	tcpClient
-	tls tlsConfig
+	tls tls.Config
 }
-
-type tlsConfig struct {
-	// MinVersion contains the minimum SSL/TLS version that is acceptable.
-	// If zero, then TLS 1.0 is taken as the minimum.
-	MinVersion uint16
-
-	// Certificates contains one or more certificate chains
-	// to present to the other side of the connection.
-	// Server configurations must include at least one certificate.
-	Certificates []tls.Certificate
-
-	// RootCAs defines the set of root certificate authorities
-	// that clients use when verifying server certificates.
-	// If RootCAs is nil, TLS uses the host's root CA set.
-	RootCAs *x509.CertPool
-}
-
-var (
-	// ErrNotACertificate indicates a PEM file to be loaded not being a valid
-	// PEM file or certificate.
-	ErrNotACertificate = errors.New("file is not a certificate")
-
-	// ErrCertificateNoKey indicate a configuration error with missing key file
-	ErrCertificateNoKey = errors.New("key file not configured")
-
-	// ErrKeyNoCertificate indicate a configuration error with missing certificate file
-	ErrKeyNoCertificate = errors.New("certificate file not configured")
-)
 
 func newTCPClient(host string) (*tcpClient, error) {
 	return &tcpClient{hostport: host}, nil
@@ -124,66 +85,10 @@ func (c *tcpClient) Close() error {
 	return err
 }
 
-func loadTLSConfig(config *TLSConfig) (*tlsConfig, error) {
-	var tlsconfig tlsConfig
-
-	// Support minimal TLS 1.0.
-	// TODO: check supported JRuby versions for logstash supported
-	//       TLS 1.1 and switch
-	tlsconfig.MinVersion = tls.VersionTLS10
-
-	hasCertificate := config.Certificate != ""
-	hasKey := config.Key != ""
-	switch {
-	case hasCertificate && !hasKey:
-		return nil, ErrCertificateNoKey
-	case !hasCertificate && hasKey:
-		return nil, ErrKeyNoCertificate
-	case hasCertificate && hasKey:
-		cert, err := tls.LoadX509KeyPair(config.Certificate, config.Key)
-		if err != nil {
-			logp.Critical("Failed loading client certificate", err)
-			return nil, err
-		}
-		tlsconfig.Certificates = []tls.Certificate{cert}
-	}
-
-	if len(config.CAs) > 0 {
-		tlsconfig.RootCAs = x509.NewCertPool()
-	}
-	for _, caFile := range config.CAs {
-		pemData, err := ioutil.ReadFile(caFile)
-		if err != nil {
-			logp.Critical("Failed reading CA certificate: %s", err)
-			return nil, err
-		}
-
-		block, _ := pem.Decode(pemData)
-		if block == nil {
-			logp.Critical("Failed to decode PEM. Is certificate %s valid?", caFile)
-			return nil, ErrNotACertificate
-		}
-		if block.Type != "CERTIFICATE" {
-			logp.Critical("PEM File %s is not a certificate", caFile)
-			return nil, ErrNotACertificate
-		}
-
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			logp.Critical("Failed to parse certificate file %s", caFile)
-			return nil, ErrNotACertificate
-		}
-
-		tlsconfig.RootCAs.AddCert(cert)
-	}
-
-	return &tlsconfig, nil
-}
-
-func newTLSClient(host string, tls tlsConfig) (*tlsClient, error) {
+func newTLSClient(host string, tls *tls.Config) (*tlsClient, error) {
 	c := tlsClient{}
 	c.hostport = host
-	c.tls = tls
+	c.tls = *tls
 	return &c, nil
 }
 

--- a/outputs/tls.go
+++ b/outputs/tls.go
@@ -1,0 +1,75 @@
+package outputs
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io/ioutil"
+
+	"github.com/elastic/libbeat/logp"
+)
+
+var (
+	// ErrNotACertificate indicates a PEM file to be loaded not being a valid
+	// PEM file or certificate.
+	ErrNotACertificate = errors.New("file is not a certificate")
+
+	// ErrCertificateNoKey indicate a configuration error with missing key file
+	ErrCertificateNoKey = errors.New("key file not configured")
+
+	// ErrKeyNoCertificate indicate a configuration error with missing certificate file
+	ErrKeyNoCertificate = errors.New("certificate file not configured")
+)
+
+// LoadTLSConfig will load a certificate from config with all TLS based keys
+// defined. If Certificate and CertificateKey are configured, client authentication
+// will be configured. If no CAs are configured, the host CA will be used by go
+// built-in TLS support.
+func LoadTLSConfig(config MothershipConfig) (*tls.Config, error) {
+	certificate := config.Certificate
+	key := config.CertificateKey
+	rootCAs := config.CAs
+	hasCertificate := certificate != ""
+	hasKey := key != ""
+
+	var certs []tls.Certificate
+	switch {
+	case hasCertificate && !hasKey:
+		return nil, ErrCertificateNoKey
+	case !hasCertificate && hasKey:
+		return nil, ErrKeyNoCertificate
+	case hasCertificate && hasKey:
+		cert, err := tls.LoadX509KeyPair(certificate, key)
+		if err != nil {
+			logp.Critical("Failed loading client certificate", err)
+			return nil, err
+		}
+		certs = []tls.Certificate{cert}
+	}
+
+	var roots *x509.CertPool
+	if len(rootCAs) > 0 {
+		roots = x509.NewCertPool()
+		for _, caFile := range rootCAs {
+			pemData, err := ioutil.ReadFile(caFile)
+			if err != nil {
+				logp.Critical("Failed reading CA certificate: %s", err)
+				return nil, err
+			}
+
+			if ok := roots.AppendCertsFromPEM(pemData); !ok {
+				return nil, ErrNotACertificate
+			}
+		}
+	}
+
+	// Support minimal TLS 1.0.
+	// TODO: check supported JRuby versions for logstash supported
+	//       TLS 1.1 and switch
+	tlsConfig := tls.Config{
+		MinVersion:   tls.VersionTLS10,
+		Certificates: certs,
+		RootCAs:      roots,
+	}
+	return &tlsConfig, nil
+}


### PR DESCRIPTION
Load TLS configuration for elasticsearch and lumberjack from config file.

If config file specifies no root CAs, the hosts root CAs will be used.

Configure certificate and certificatekey for TLS client authentication.