### PR TITLE
logp syslog build constraints

### DIFF
--- a/logp/syslog_other.go
+++ b/logp/syslog_other.go
@@ -1,4 +1,4 @@
-// +build windows
+// +build windows nacl plan9
 
 package logp
 

--- a/logp/syslog_unix.go
+++ b/logp/syslog_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!nacl,!plan9
 
 package logp
 


### PR DESCRIPTION
Modifying logp's syslog code to have the same build constraints as the golang 1log/syslog1 package. It shouldn't have any effect on any of our beats. It just fixes an inconsistency between our package and golang that I noticed when testing cross-compilation.