### PR TITLE
Use the Beat name in the default configuration file path

### DIFF
--- a/beat/beat.go
+++ b/beat/beat.go
@@ -63,7 +63,7 @@ func (beat *Beat) CommandLineSetup() {
 	err := cfgfile.ChangeDefaultCfgfileFlag(beat.Name)
 	if err != nil {
 		fmt.Printf("Failed to fix the -c flag: %v\n", err)
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	flag.Parse()

--- a/beat/beat.go
+++ b/beat/beat.go
@@ -59,6 +59,9 @@ func NewBeat(name string, version string, bt Beater) *Beat {
 // To set additional cmd line args use the beat.CmdLine type before calling the function
 func (beat *Beat) CommandLineSetup() {
 
+	// The -c flag is treated separately because it needs the Beat name
+	cfgfile.AddConfigCliFlag(beat.Name)
+
 	flag.Parse()
 
 	if *printVersion {

--- a/beat/beat.go
+++ b/beat/beat.go
@@ -60,7 +60,11 @@ func NewBeat(name string, version string, bt Beater) *Beat {
 func (beat *Beat) CommandLineSetup() {
 
 	// The -c flag is treated separately because it needs the Beat name
-	cfgfile.AddConfigCliFlag(beat.Name)
+	err := cfgfile.ChangeDefaultCfgfileFlag(beat.Name)
+	if err != nil {
+		fmt.Printf("Failed to fix the -c flag: %v\n", err)
+		os.Exit(0)
+	}
 
 	flag.Parse()
 

--- a/cfgfile/cfgfile.go
+++ b/cfgfile/cfgfile.go
@@ -14,8 +14,14 @@ var testConfig *bool
 
 func init() {
 	// The default config cannot include the beat name as it is not initialised when this function is called
-	configfile = flag.String("c", "/etc/beat/beat.yml", "Configuration file")
 	testConfig = flag.Bool("test", false, "Test configuration and exit.")
+}
+
+// AddConfigCliFlag adds the `-c` command line parameter with the default
+// set depending on the beat name. Needs to be called before parsing the flags.
+func AddConfigCliFlag(beatName string) {
+	configfile = flag.String("c", fmt.Sprintf("/etc/%s/%s.yml", beatName, beatName),
+		"Configuration file")
 }
 
 // Read reads the configuration from a yaml file into the given interface structure.

--- a/cfgfile/cfgfile.go
+++ b/cfgfile/cfgfile.go
@@ -13,15 +13,21 @@ var configfile *string
 var testConfig *bool
 
 func init() {
-	// The default config cannot include the beat name as it is not initialised when this function is called
+	// The default config cannot include the beat name as it is not initialised when this
+	// function is called, but see ChangeDefaultCfgfileFlag
+	configfile = flag.String("c", "/etc/beat/beat.yml", "Configuration file")
 	testConfig = flag.Bool("test", false, "Test configuration and exit.")
 }
 
-// AddConfigCliFlag adds the `-c` command line parameter with the default
-// set depending on the beat name. Needs to be called before parsing the flags.
-func AddConfigCliFlag(beatName string) {
-	configfile = flag.String("c", fmt.Sprintf("/etc/%s/%s.yml", beatName, beatName),
-		"Configuration file")
+// ChangeDefaultCfgfileFlag replaces the value and default value for the `-c` flag so that
+// it reflects the beat name.
+func ChangeDefaultCfgfileFlag(beatName string) error {
+	cliflag := flag.Lookup("c")
+	if cliflag == nil {
+		return fmt.Errorf("Flag -c not found")
+	}
+	cliflag.DefValue = fmt.Sprintf("/etc/%s/%s.yml", beatName, beatName)
+	return cliflag.Value.Set(cliflag.DefValue)
 }
 
 // Read reads the configuration from a yaml file into the given interface structure.


### PR DESCRIPTION
Adds a bit of extra complexity but fortunately requires no changes to the Beats, it's a change internal in libbeat.

Should fix #66.