### PR TITLE
Add version variable for Elasticsearch, Kibana and beats-dashboards.

### DIFF
--- a/docs/gettingstarted.asciidoc
+++ b/docs/gettingstarted.asciidoc
@@ -31,32 +31,32 @@ mac for OS X):
 
 deb:
 
-[source,shell]
+["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo apt-get install openjdk-7-jre
-curl -L -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.5.2.deb
-sudo dpkg -i elasticsearch-1.5.2.deb
+curl -L -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-{ES-version}.deb
+sudo dpkg -i elasticsearch-{ES-version}.deb
 sudo /etc/init.d/elasticsearch start
 ----------------------------------------------------------------------
 
 rpm:
 
-[source,shell]
+["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo yum install java-1.7.0-openjdk
-curl -L -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.5.2.noarch.rpm
-sudo rpm -i elasticsearch-1.5.2.noarch.rpm
+curl -L -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-{ES-version}.noarch.rpm
+sudo rpm -i elasticsearch-{ES-version}.noarch.rpm
 sudo service elasticsearch start
 ----------------------------------------------------------------------
 
 mac:
 
-[source,shell]
+["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 # install Java, e.g. from: https://www.java.com/en/download/manual.jsp
-curl -L -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.5.2.zip
-unzip elasticsearch-1.5.2.zip
-cd elasticsearch-1.5.2
+curl -L -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-{ES-version}.zip
+unzip elasticsearch-{ES-version}.zip
+cd elasticsearch-{ES-version}
 ./bin/elasticsearch
 ----------------------------------------------------------------------
 
@@ -180,21 +180,21 @@ Use the following commands to download and run Kibana:
 
 deb or rpm:
 
-[source,shell]
+["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-curl -L -O https://download.elastic.co/kibana/kibana/kibana-4.0.2-linux-x64.tar.gz
-tar xzvf kibana-4.0.2-linux-x64.tar.gz
-cd kibana-4.0.2-linux-x64/
+curl -L -O https://download.elastic.co/kibana/kibana/kibana-{Kibana-version}-linux-x64.tar.gz
+tar xzvf kibana-{Kibana-version}-linux-x64.tar.gz
+cd kibana-{Kibana-version}-linux-x64/
 ./bin/kibana
 ----------------------------------------------------------------------
 
 mac:
 
-[source,shell]
+["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-curl -L -O https://download.elastic.co/kibana/kibana/kibana-4.0.2-darwin-x64.tar.gz
-tar xzvf kibana-4.0.2-darwin-x64.tar.gz
-cd kibana-4.0.2-darwin-x64/
+curl -L -O https://download.elastic.co/kibana/kibana/kibana-{Kibana-version}-darwin-x64.tar.gz
+tar xzvf kibana-{Kibana-version}-darwin-x64.tar.gz
+cd kibana-{Kibana-version}-darwin-x64/
 ./bin/kibana
 ----------------------------------------------------------------------
 
@@ -221,11 +221,11 @@ demonstrate what is possible based on the packet data.
 
 To load the sample pages, follow these steps:
 
-[source,shell]
+["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-curl -L -O https://download.elastic.co/beats/packetbeat/beats-dashboards-1.0.0-beta2.tar.gz
-tar xzvf beats-dashboards-1.0.0-beta2.tar.gz
-cd beats-dashboards-1.0.0-beta2/
+curl -L -O http://download.elastic.co/beats/dashboards/beats-dashboards-{Dashboards-version}.tar.gz
+tar xzvf beats-dashboards-{Dashboards-version}.tar.gz
+cd beats-dashboards-{Dashboards-version}/
 ./load.sh
 ----------------------------------------------------------------------
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,8 @@
 [[beats-reference]]
 = Beats Platform Reference
+:ES-version: 1.7.2
+:Kibana-version: 4.1.2
+:Dashboards-version: 1.0.0-beta3
 
 include::./overview.asciidoc[]
 


### PR DESCRIPTION
Configure what version of Elasticsearch, Kibana, Logstash (needs to be done) and beats-dashboard to be downloaded and installed.

https://github.com/elastic/packetbeat/issues/235 suggests to use _latest_ for Elasticsearch packages. For Kibana, there is kibana-latest, but from what I can see it doesn't include a binary file.

I think it's better if don't use the _latest_ and choose the version of Elasticsearch and Kibana that work better with each Beat release. 