### PR TITLE
enhance lumberjack send mode

### DIFF
--- a/outputs/lumberjack/lumberjack.go
+++ b/outputs/lumberjack/lumberjack.go
@@ -99,7 +99,7 @@ func (lj *lumberjack) init(
 		if loadBalance {
 			mode, err = newLoadBalancerMode(clients, sendRetries, waitRetry, timeout)
 		} else {
-			mode, err = newFailOverConnectionMode(clients, waitRetry, timeout)
+			mode, err = newFailOverConnectionMode(clients, sendRetries, waitRetry, timeout)
 		}
 	}
 	if err != nil {

--- a/outputs/lumberjack/lumberjack.go
+++ b/outputs/lumberjack/lumberjack.go
@@ -86,16 +86,17 @@ func (lj *lumberjack) init(
 		return err
 	}
 
+	sendRetries := defaultSendRetries
+	if config.Max_retries != nil {
+		sendRetries = *config.Max_retries
+	}
+
 	var mode ConnectionMode
 	if len(clients) == 1 {
-		mode, err = newSingleConnectionMode(clients[0], waitRetry, timeout)
+		mode, err = newSingleConnectionMode(clients[0], sendRetries, waitRetry, timeout)
 	} else {
 		loadBalance := config.LoadBalance == nil || *config.LoadBalance
 		if loadBalance {
-			sendRetries := defaultSendRetries
-			if config.Max_retries != nil {
-				sendRetries = *config.Max_retries
-			}
 			mode, err = newLoadBalancerMode(clients, sendRetries, waitRetry, timeout)
 		} else {
 			mode, err = newFailOverConnectionMode(clients, waitRetry, timeout)

--- a/outputs/lumberjack/modes_test.go
+++ b/outputs/lumberjack/modes_test.go
@@ -168,6 +168,7 @@ func TestSingleSend(t *testing.T) {
 			connect:   connectOK,
 			publish:   collectPublish(&collected),
 		},
+		3,
 		0,
 		100*time.Millisecond,
 	)
@@ -181,9 +182,10 @@ func TestSingleConnectFailConnect(t *testing.T) {
 		&mockClient{
 			connected: false,
 			close:     closeOK,
-			connect:   failConnect(5, errFail),
+			connect:   failConnect(2, errFail),
 			publish:   collectPublish(&collected),
 		},
+		3,
 		0,
 		100*time.Millisecond,
 	)
@@ -207,6 +209,7 @@ func TestFailoverSingleSend(t *testing.T) {
 				publish:   collectPublish(&collected),
 			},
 		},
+		3,
 		0,
 		100*time.Millisecond,
 	)
@@ -233,6 +236,7 @@ func TestFailoverFlakyConnections(t *testing.T) {
 				publish:   publishTimeoutEvery(2, collectPublish(&collected)),
 			},
 		},
+		3,
 		1*time.Millisecond,
 		100*time.Millisecond,
 	)


### PR DESCRIPTION
- unify retry handling
- configurable number of retries (of 0, output plugins block until send)
- fix possible deadlock in load balancer, if all worker connections start failing at about the same time.