### PR TITLE
expose more TLS config options

### DIFF
--- a/outputs/elasticsearch/api.go
+++ b/outputs/elasticsearch/api.go
@@ -62,24 +62,15 @@ func NewElasticsearch(
 	tls *tls.Config,
 	username, password string,
 ) *Elasticsearch {
-
 	var pool ConnectionPool
 	_ = pool.SetConnections(urls, username, password) // never errors
 
-	if tls != nil {
-		return &Elasticsearch{
-			connectionPool: pool,
-			client: &http.Client{
-				Transport: &http.Transport{TLSClientConfig: tls},
-			},
-			MaxRetries: defaultMaxRetries,
-		}
-	}
-
 	return &Elasticsearch{
 		connectionPool: pool,
-		client:         &http.Client{},
-		MaxRetries:     defaultMaxRetries,
+		client: &http.Client{
+			Transport: &http.Transport{TLSClientConfig: tls},
+		},
+		MaxRetries: defaultMaxRetries,
 	}
 }
 

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -73,7 +73,7 @@ func (out *elasticsearchOutput) Init(
 		urls = append(urls, url)
 	}
 
-	tlsConfig, err := outputs.LoadTLSConfig(config)
+	tlsConfig, err := outputs.LoadTLSConfig(config.TLS)
 	if err != nil {
 		return err
 	}

--- a/outputs/lumberjack/lumberjack.go
+++ b/outputs/lumberjack/lumberjack.go
@@ -55,7 +55,7 @@ func (lj *lumberjack) init(
 ) error {
 	useTLS := false
 	if config.TLS != nil {
-		useTLS = *config.TLS
+		useTLS = !config.TLS.Disabled
 	}
 
 	timeout := lumberjackDefaultTimeout
@@ -67,7 +67,7 @@ func (lj *lumberjack) init(
 	var err error
 	if useTLS {
 		var tlsConfig *tls.Config
-		tlsConfig, err = outputs.LoadTLSConfig(config)
+		tlsConfig, err = outputs.LoadTLSConfig(config.TLS)
 		if err != nil {
 			return err
 		}

--- a/outputs/lumberjack/lumberjack_test.go
+++ b/outputs/lumberjack/lumberjack_test.go
@@ -163,7 +163,6 @@ func genCertsIfMIssing(
 }
 
 func TestLumberjackTCP(t *testing.T) {
-	useTLS := false
 	var serverErr error
 	var win, data *message
 
@@ -175,7 +174,7 @@ func TestLumberjackTCP(t *testing.T) {
 
 	// create lumberjack output client
 	config := outputs.MothershipConfig{
-		TLS:     &useTLS,
+		TLS:     nil,
 		Timeout: 1,
 		Hosts:   []string{listener.Addr().String()},
 	}
@@ -238,17 +237,17 @@ func TestLumberjackTLS(t *testing.T) {
 	}
 
 	// create lumberjack output client
-	useTLS := true
 	config := outputs.MothershipConfig{
-		TLS:            &useTLS,
-		Timeout:        5,
-		Hosts:          []string{tcpListener.Addr().String()},
-		Certificate:    pem,
-		CertificateKey: key,
-		CAs:            []string{pem},
+		TLS: &outputs.TLSConfig{
+			Certificate:    pem,
+			CertificateKey: key,
+			CAs:            []string{pem},
+		},
+		Timeout: 5,
+		Hosts:   []string{tcpListener.Addr().String()},
 	}
 
-	tlsConfig, err := outputs.LoadTLSConfig(config)
+	tlsConfig, err := outputs.LoadTLSConfig(config.TLS)
 	if err != nil {
 		tcpListener.Close()
 		t.Fatalf("failed to load certificates")

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -30,11 +30,7 @@ type MothershipConfig struct {
 	Flush_interval     *int
 	Bulk_size          *int
 	Max_retries        *int
-	TLS                *bool
-	Certificate        string
-	CertificateKey     string
-	CAs                []string
-	TLSInsecure        *bool
+	TLS                *TLSConfig
 }
 
 type Outputer interface {

--- a/outputs/tls.go
+++ b/outputs/tls.go
@@ -19,13 +19,39 @@ var (
 
 	// ErrKeyNoCertificate indicate a configuration error with missing certificate file
 	ErrKeyNoCertificate = errors.New("certificate file not configured")
+
+	// ErrInvalidTLSVersion indicates an unknown tls version string given.
+	ErrInvalidTLSVersion = errors.New("invalid TLS version string")
+
+	// ErrUnknownCipherSuite indicates an unknown tls cipher suite being used
+	ErrUnknownCipherSuite = errors.New("unknown cypher suite")
+
+	// ErrUnknownCurveID indicates an unknown curve id has been configured
+	ErrUnknownCurveID = errors.New("unknown curve id")
 )
+
+// TLSConfig defines config file options for TLS clients.
+type TLSConfig struct {
+	Disabled       bool
+	Certificate    string
+	CertificateKey string
+	CAs            []string
+	TLSInsecure    *bool
+	CipherSuites   []string
+	MinVersion     *string
+	MaxVersion     *string
+	CurveTypes     []string
+}
 
 // LoadTLSConfig will load a certificate from config with all TLS based keys
 // defined. If Certificate and CertificateKey are configured, client authentication
 // will be configured. If no CAs are configured, the host CA will be used by go
 // built-in TLS support.
-func LoadTLSConfig(config MothershipConfig) (*tls.Config, error) {
+func LoadTLSConfig(config *TLSConfig) (*tls.Config, error) {
+	if config == nil || config.Disabled {
+		return nil, nil
+	}
+
 	certificate := config.Certificate
 	key := config.CertificateKey
 	rootCAs := config.CAs
@@ -68,14 +94,102 @@ func LoadTLSConfig(config MothershipConfig) (*tls.Config, error) {
 		insecureSkipVerify = *config.TLSInsecure
 	}
 
-	// Support minimal TLS 1.0.
-	// TODO: check supported JRuby versions for logstash supported
-	//       TLS 1.1 and switch
+	minVersion, err := parseTLSVersion(config.MinVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	maxVersion, err := parseTLSVersion(config.MaxVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	cipherSuites, err := parseTLSCipherSuites(config.CipherSuites)
+	if err != nil {
+		return nil, err
+	}
+
+	curveIDs, err := parseCurveTypes(config.CurveTypes)
+	if err != nil {
+		return nil, err
+	}
+
 	tlsConfig := tls.Config{
-		MinVersion:         tls.VersionTLS10,
+		MinVersion:         minVersion,
+		MaxVersion:         maxVersion,
 		Certificates:       certs,
 		RootCAs:            roots,
 		InsecureSkipVerify: insecureSkipVerify,
+		CipherSuites:       cipherSuites,
+		CurvePreferences:   curveIDs,
 	}
 	return &tlsConfig, nil
+}
+
+func parseTLSVersion(s *string) (uint16, error) {
+	if s == nil {
+		return 0, nil
+	}
+
+	switch *s {
+	case "SSL-3.0":
+		return tls.VersionSSL30, nil
+	case "1.0":
+		return tls.VersionTLS10, nil
+	case "1.1":
+		return tls.VersionTLS11, nil
+	case "1.2":
+		return tls.VersionTLS12, nil
+	default:
+		return 0, ErrInvalidTLSVersion
+	}
+}
+
+func parseTLSCipherSuites(names []string) ([]uint16, error) {
+	suites := map[string]uint16{
+		"RSA-RC4-128-SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
+		"RSA-3DES-EDE-CBC-SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+		"RSA-AES-128-CBC-SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"RSA-AES-256-CBC-SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"ECDHE-ECDSA-RC4-128-SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+		"ECDHE-ECDSA-AES-128-CBC-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-ECDSA-AES-256-CBC-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"ECDHE-RSA-RC4-128-SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+		"ECDHE-RSA-3DES-EDE-CBC-SHA":     tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		"ECDHE-RSA-AES-128-CBC-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-RSA-AES-256-CBC-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"ECDHE-RSA-AES-128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-ECDSA-AES-128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-RSA-AES-256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-ECDSA-AES-256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	}
+
+	var list []uint16
+	for _, name := range names {
+		id, ok := suites[name]
+		if !ok {
+			return nil, ErrUnknownCipherSuite
+		}
+
+		list = append(list, id)
+	}
+	return list, nil
+}
+
+func parseCurveTypes(names []string) ([]tls.CurveID, error) {
+	curveIDs := map[string]tls.CurveID{
+		"P256": tls.CurveP256,
+		"P384": tls.CurveP384,
+		"P521": tls.CurveP521,
+	}
+
+	var list []tls.CurveID
+	for _, name := range names {
+		id, ok := curveIDs[name]
+		if !ok {
+			return nil, ErrUnknownCurveID
+		}
+		list = append(list, id)
+	}
+	return list, nil
 }


### PR DESCRIPTION
Expose all TLS config options used by golang tls clients via config
file.

TLS config parsing requires go1.5 to build (#123). Requirement due to TLS cipher suites added in go1.5.