### PR TITLE
Switch travis to docker-compose setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,17 @@
+sudo: required
+services:
+  - docker
+
 language: go
 
 go:
   - 1.5.1
 
-sudo: false
-
 env:
-  - TARGETS="check full-coverage"
+  - TARGETS="check"
+  - TARGETS="testsuite ES_HOST=elasticsearch-172"
+  - TARGETS="testsuite ES_HOST=elasticsearch-200"
   - TARGETS="crosscompile"
-
-services:
-  - redis-server
-  - elasticsearch
-
-addons:
-  apt:
-    packages:
-      - python-virtualenv
-      - geoip-database
 
 before_install:
   # Redo the travis setup but with the elastic/libbeat path. This is needed so the package path is correct
@@ -25,12 +19,13 @@ before_install:
   - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/elastic/libbeat/
   - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/elastic/libbeat
   - cd $HOME/gopath/src/github.com/elastic/libbeat
+  # Docker-compose installation
+  - curl -L https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
 
 addonsbefore_install:
   - ln -s $TRAVIS_BUILD_DIR $HOME/gopath/src/libbeat
-
-before_script:
-  - sleep 10
 
 install:
   - make deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5
+FROM golang:1.5.1
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 ## Install go package dependencies

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ GODEP=$(GOPATH)/bin/godep
 export PATH := ./bin:$(PATH)
 GOFILES = $(shell find . -type f -name '*.go')
 SHELL=/bin/bash
+ES_HOST?=""
 
 .PHONY: build
 build:
@@ -79,14 +80,14 @@ stop-environment:
 # Runs the full test suite and puts out the result. This can be run on any docker-machine (local, remote)
 .PHONY: testsuite
 testsuite: build-image
-	docker-compose run libbeat make testlong
+	docker-compose run -e ES_HOST=${ES_HOST} libbeat make testlong
 	# Copy coverage file back to host
 	mkdir -p coverage
 	docker cp libbeat_libbeat_run_1:/go/src/github.com/elastic/libbeat/coverage/unit.cov $(shell pwd)/coverage/
 	docker cp libbeat_libbeat_run_1:/go/src/github.com/elastic/libbeat/coverage/unit.html $(shell pwd)/coverage/
 
 # Sets up docker-compose locally for jenkins so no global installation is needed
-.PHONY: testsuite
+.PHONY: docker-compose-setup
 docker-compose-setup:
 	mkdir -p bin
 	curl -L https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m` > bin/docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,17 @@ libbeat:
   build: .
   links:
     - redis
-    - elasticsearch
+    - elasticsearch-172
+    - elasticsearch-200
   environment:
-    - ES_HOST=elasticsearch
+    - ES_HOST=elasticsearch-172
     - ES_PORT=9200
     - REDIS_HOST=redis
     - REDIS_PORT=6379
-elasticsearch:
-  image: elasticsearch
+elasticsearch-172:
+  image: elasticsearch:1.7.2
+elasticsearch-200:
+  image: elasticsearch:2.0.0-beta2
+  command: elasticsearch -Des.network.host=0.0.0.0
 redis:
   image: redis


### PR DESCRIPTION
This makes the travis setup identical to the jenkins setup. In addition it tests for two different versions of elasticsearch.