### PR TITLE
Make only host and port depreciated in the config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,6 @@ All notable changes to this project will be documented in this file based on the
 ### Improvements
 
 ### Deprecated
+
+ * host and port configuration options are deprecated. They are replaced by the hosts
+ configuration option.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -169,17 +169,12 @@ Example configuration:
 ------------------------------------------------------------------------------
 output:
   elasticsearch:
-    # Uncomment out this option if you want to output to Elasticsearch. The
-    # default is false.
+
+    # Enable Elasticsearch as output
     enabled: true
 
-    # Set the host and port where to find Elasticsearch.
-    hosts: ["localhost:9200"]
-
-    # Optional protocol and basic auth credentials
-    # protocol: "https"
-    # username: "admin"
-    # password: "s3cr3t"
+    # The Elasticsearch cluster
+    hosts: ["http://10.45.3.2", "http://10.45.3.1/elasticsearch"]
 
     # Comment this option if you don't want to store the topology in
     # Elasticsearch. The default is false.
@@ -189,9 +184,6 @@ output:
     # Optional index name. The default is packetbeat and generates
     # [packetbeat-]YYYY.MM.DD keys.
     index: "packetbeat"
-
-    # Optional HTTP Path
-    path: "/elasticsearch"
 
     # List of root certificates for HTTPS server verifications
     cas: ["/etc/pki/root/ca.pem"]
@@ -204,31 +196,104 @@ output:
 
 ------------------------------------------------------------------------------
 
+To enable SSL, just add `https` to all URLs defined under __hosts__.
+
+[source,yaml]
+------------------------------------------------------------------------------
+
+output:
+  elasticsearch:
+	
+    # Enable Elasticsearch as output
+    enabled: true
+
+    # The Elasticsearch cluster
+    hosts: ["https://10.45.3.2", "https://10.45.3.1"]
+
+    # Comment this option if you don't want to store the topology in
+    # Elasticsearch. The default is false.
+    # This option makes sense only for Packetbeat
+    save_topology: true
+
+    # SSL configurations 
+    username: "admin"
+    password: "s3cr3t"
+
+------------------------------------------------------------------------------
+
+If the Elasticsearch nodes are defined by `IP:PORT` then add `protocol: https` to your yaml file.
+
+[source,yaml]
+------------------------------------------------------------------------------
+
+output:
+  elasticsearch:
+	
+    # Enable Elasticsearch as output
+    enabled: true
+
+    # The Elasticsearch cluster
+    hosts: ["10.45.3.2", "10.45.3.1"]
+    protocol: "https"
+
+    # Comment this option if you don't want to store the topology in
+    # Elasticsearch. The default is false.
+    # This option makes sense only for Packetbeat
+    save_topology: true
+
+    # SSL configurations 
+    username: "admin"
+    password: "s3cr3t"
+
+------------------------------------------------------------------------------
+
 
 ===== enabled
 
 Boolean option that enables Elasticsearch as output. The default is true.
 
+[[hosts-option]]
 ===== hosts
 
 The list of Elasticsearch nodes to which to connect. The events are distributed to
 these nodes in round robin order. If one node becomes unreachable, the event is
-automatically sent to another node.
+automatically sent to another node. Each Elasticsearch node can be defined as an `URL` or `IP:PORT`.
+Examples: `http://192.15.3.2`, `https://es.found.io:9230` or `192.24.3.2:9300`.
+If no port is specified, `9200` is used.
 
-===== host
+Note:: In case of `IP:PORT`, the _scheme_ and _path_ is taken from the <<protocol-option>> and <<path-option>> config
+options. 
 
-The host of the Elasticsearch server. This option is deprecated and only used if
-the `hosts` option is not present.
+[source,yaml]
+------------------------------------------------------------------------------
+output:
+  elasticsearch:
 
-===== port
+    # Enable Elasticsearch as output
+    enabled: true
 
-The port of the Elasticsearch server. This option is deprecated and only used if
-the `hosts` option is not present.
+    # The Elasticsearch cluster
+    hosts: ["10.45.3.2:9220", "10.45.3.1:9230"]
 
-===== protocol
+    # Optional http or https. Default is http
+    protocol: https 
 
-The name of the protocol Elasticsearch is reachable on. The options are:
-`http` or `https`. The default is `http`.
+    # HTTP Path at which each Elasticsearch server lives
+    path: /elasticsearch
+------------------------------------------------------------------------------
+
+In the previous example, the Elasticsearch nodes are available at https://10.45.3.2:9220/elasticsearch and
+https://10.45.3.1:9230/elasticsearch.
+
+
+===== host (DEPRECATED)
+
+The host of the Elasticsearch server. This option is deprecated as it is replaced by <<hosts-option>>.
+
+===== port (DEPRECATED)
+
+The port of the Elasticsearch server. This option is deprecated as it is replaced by <<hosts-option>>.
+
 
 ===== username
 
@@ -237,6 +302,19 @@ Basic authentication username for connecting to Elasticsearch.
 ===== password
 
 Basic authentication password for connecting to Elasticsearch.
+
+[[protocol-option]]
+===== protocol
+
+The name of the protocol Elasticsearch is reachable on. The options are:
+`http` or `https`. The default is `http`.
+
+[[path-option]]
+===== path
+
+An HTTP path prefix that is prepended to the HTTP API calls. This is useful for
+the cases where Elasticsearch listens behind an HTTP reverse proxy that exports
+the API under a custom prefix.
 
 
 ===== index
@@ -260,12 +338,6 @@ The default is 10000.
 The number of seconds to wait for new events between two bulk API index requests.
 If `bulk_max_size` is reached before this interval expires, addition bulk index
 requests are made.
-
-===== path
-
-An HTTP path prefix that is prepended to the HTTP API calls. This is useful for
-the cases where Elasticsearch listens behind an HTTP reverse proxy that exports
-the API under a custom prefix.
 
 ===== save_topology
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -215,7 +215,7 @@ output:
     # This option makes sense only for Packetbeat
     save_topology: true
 
-    # SSL configurations 
+    # HTTP basic auth
     username: "admin"
     password: "s3cr3t"
 
@@ -241,7 +241,7 @@ output:
     # This option makes sense only for Packetbeat
     save_topology: true
 
-    # SSL configurations 
+    # HTTP basic auth
     username: "admin"
     password: "s3cr3t"
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -307,7 +307,7 @@ Basic authentication password for connecting to Elasticsearch.
 ===== protocol
 
 The name of the protocol Elasticsearch is reachable on. The options are:
-`http` or `https`. The default is `http`.
+`http` or `https`. The default is `http`. Its value is overwritten by the scheme available in the URL.
 
 [[path-option]]
 ===== path

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -228,12 +228,14 @@ If the Elasticsearch nodes are defined by `IP:PORT` then add `protocol: https` t
 
 output:
   elasticsearch:
-	
+
     # Enable Elasticsearch as output
     enabled: true
 
     # The Elasticsearch cluster
     hosts: ["10.45.3.2", "10.45.3.1"]
+
+    # Optional http or https. Default is http
     protocol: "https"
 
     # Comment this option if you don't want to store the topology in
@@ -276,7 +278,7 @@ output:
     hosts: ["10.45.3.2:9220", "10.45.3.1:9230"]
 
     # Optional http or https. Default is http
-    protocol: https 
+    protocol: https
 
     # HTTP Path at which each Elasticsearch server lives
     path: /elasticsearch

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -261,7 +261,7 @@ automatically sent to another node. Each Elasticsearch node can be defined as an
 Examples: `http://192.15.3.2`, `https://es.found.io:9230` or `192.24.3.2:9300`.
 If no port is specified, `9200` is used.
 
-Note:: In case of `IP:PORT`, the _scheme_ and _path_ is taken from the <<protocol-option>> and <<path-option>> config
+Note:: In case of `IP:PORT`, the _scheme_ and _path_ are taken from the <<protocol-option>> and <<path-option>> config
 options. 
 
 [source,yaml]

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -292,7 +292,7 @@ func (out *elasticsearchOutput) BulkPublish(
 
 // Creates the url based on the url configuration.
 // Adds missing parts with defaults (scheme, host, port)
-func getUrl(default_scheme string, default_path string, rawUrl string) (string, error) {
+func getUrl(defaultScheme string, defaultPath string, rawUrl string) (string, error) {
 
 	urlStruct, err := url.Parse(rawUrl)
 
@@ -334,12 +334,12 @@ func getUrl(default_scheme string, default_path string, rawUrl string) (string, 
 
 	// Assign default scheme if not set
 	if urlStruct.Scheme == "" {
-		urlStruct.Scheme = default_scheme
+		urlStruct.Scheme = defaultScheme
 	}
 
 	// Assign default path if not set
 	if urlStruct.Path == "" {
-		urlStruct.Path = default_path
+		urlStruct.Path = defaultPath
 	}
 
 	// Check if ipv6

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -75,8 +75,7 @@ func (out *elasticsearchOutput) Init(
 			urls = append(urls, url)
 		}
 	} else {
-		// use host and port settings
-		// TODO: Deprecate usage of host and port always use hosts
+		// usage of host and port is deprecated as it is replaced by hosts
 		url := fmt.Sprintf("%s://%s:%d%s", config.Protocol, config.Host, config.Port, config.Path)
 		urls = append(urls, url)
 	}

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -67,7 +67,7 @@ func (out *elasticsearchOutput) Init(
 	if len(config.Hosts) > 0 {
 		// use hosts setting
 		for _, host := range config.Hosts {
-			url, err := getUrl(host)
+			url, err := getUrl(config.Protocol, config.Path, host)
 
 			if err != nil {
 				logp.Err("Invalid host param set: %s, Error: %v", host, err)
@@ -76,7 +76,7 @@ func (out *elasticsearchOutput) Init(
 		}
 	} else {
 		// use host and port settings
-		// TODO: Deprecate usage of host, always use hosts
+		// TODO: Deprecate usage of host and port always use hosts
 		url := fmt.Sprintf("%s://%s:%d%s", config.Protocol, config.Host, config.Port, config.Path)
 		urls = append(urls, url)
 	}
@@ -293,7 +293,7 @@ func (out *elasticsearchOutput) BulkPublish(
 
 // Creates the url based on the url configuration.
 // Adds missing parts with defaults (scheme, host, port)
-func getUrl(rawUrl string) (string, error) {
+func getUrl(default_scheme string, default_path string, rawUrl string) (string, error) {
 
 	urlStruct, err := url.Parse(rawUrl)
 
@@ -304,7 +304,7 @@ func getUrl(rawUrl string) (string, error) {
 	host := ""
 	port := ""
 
-	// If url doesn't have a scheme, host is written into path
+	// If url doesn't have a scheme, host is written into path. For example: 192.168.3.7
 	if urlStruct.Host == "" {
 		urlStruct.Host = urlStruct.Path
 		urlStruct.Path = ""
@@ -335,7 +335,12 @@ func getUrl(rawUrl string) (string, error) {
 
 	// Assign default scheme if not set
 	if urlStruct.Scheme == "" {
-		urlStruct.Scheme = "http"
+		urlStruct.Scheme = default_scheme
+	}
+
+	// Assign default path if not set
+	if urlStruct.Path == "" {
+		urlStruct.Path = default_path
 	}
 
 	// Check if ipv6

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -356,7 +356,18 @@ func TestGetUrl(t *testing.T) {
 	}
 
 	for input, output := range inputOutput {
-		urlNew, err := getUrl(input)
+		urlNew, err := getUrl("http", "", input)
+		assert.Nil(t, err)
+		assert.Equal(t, output, urlNew)
+	}
+
+	inputOutputWithDefaults := map[string]string{
+		"http://localhost":                          "http://localhost:9200/hello",
+		"192.156.4.5":                               "https://192.156.4.5:9200/hello",
+		"http://username:password@es.found.io:9324": "http://username:password@es.found.io:9324/hello",
+	}
+	for input, output := range inputOutputWithDefaults {
+		urlNew, err := getUrl("https", "/hello", input)
 		assert.Nil(t, err)
 		assert.Equal(t, output, urlNew)
 	}


### PR DESCRIPTION
Use the _hosts_ to pass a list of Elasticsearch nodes. _host_ and _port_ config options are depreciated.
Keep _protocol_ and _path_ as the default values for all urls defined under hosts. If scheme or path is
present in the hosts, then its value will be used.

<pre>
output:
    elasticsearch:
        enabled: true
        hosts: ["192.168.3.4:9230", "10.43.1.3"]
        protocol: https # default http
        path: /elasticsearch
        username: "admin"
        password: "s3cr3t"
</pre>
connects to the ES nodes: [https://192.168.3.4:9230/elasticsearch, https://10.43.1.3:9200/elasticsearch]
with the username and password specified. The same username and password for all hosts.

Note: If you add username:password in the hosts, they will be overwritten by the values of the username and password
options.