### PR TITLE
Cache: optional per element timeout

### DIFF
--- a/common/cache.go
+++ b/common/cache.go
@@ -86,7 +86,16 @@ func newCache(d time.Duration, initialSize int, l RemovalListener, t clock) *Cac
 // PutIfAbsent writes the given key and value to the cache only if the key is
 // absent from the cache. Nil is returned if the key-value pair were written,
 // otherwise the old value is returned.
-func (c *Cache) PutIfAbsent(k Key, v Value, timeout time.Duration) Value {
+func (c *Cache) PutIfAbsent(k Key, v Value) Value {
+	return c.PutIfAbsentWithTimeout(k, v, 0)
+}
+
+// PutIfAbsentWithTimeout writes the given key and value to the cache only if
+// the key is absent from the cache. Nil is returned if the key-value pair were
+// written, otherwise the old value is returned.
+// The cache expiration time will be overwritten by timeout of the key being
+// inserted.
+func (c *Cache) PutIfAbsentWithTimeout(k Key, v Value, timeout time.Duration) Value {
 	c.Lock()
 	defer c.Unlock()
 	oldValue, exists := c.get(k)
@@ -101,7 +110,16 @@ func (c *Cache) PutIfAbsent(k Key, v Value, timeout time.Duration) Value {
 // Put writes the given key and value to the map replacing any existing value
 // if it exists. The previous value associated with the key returned or nil
 // if the key was not present.
-func (c *Cache) Put(k Key, v Value, timeout time.Duration) Value {
+func (c *Cache) Put(k Key, v Value) Value {
+	return c.PutWithTimeout(k, v, 0)
+}
+
+// PutWithTimeout writes the given key and value to the map replacing any
+// existing value if it exists. The previous value associated with the key
+// returned or nil if the key was not present.
+// The cache expiration time will be overwritten by timeout of the key being
+// inserted.
+func (c *Cache) PutWithTimeout(k Key, v Value, timeout time.Duration) Value {
 	c.Lock()
 	defer c.Unlock()
 	oldValue, _ := c.get(k)
@@ -111,7 +129,15 @@ func (c *Cache) Put(k Key, v Value, timeout time.Duration) Value {
 
 // Replace overwrites the value for a key only if the key exists. The old
 // value is returned if the value is updated, otherwise nil is returned.
-func (c *Cache) Replace(k Key, v Value, timeout time.Duration) Value {
+func (c *Cache) Replace(k Key, v Value) Value {
+	return c.ReplaceWithTimeout(k, v, 0)
+}
+
+// ReplaceWithTimeout overwrites the value for a key only if the key exists. The
+// old value is returned if the value is updated, otherwise nil is returned.
+// The cache expiration time will be overwritten by timeout of the key being
+// inserted.
+func (c *Cache) ReplaceWithTimeout(k Key, v Value, timeout time.Duration) Value {
 	c.Lock()
 	defer c.Unlock()
 	oldValue, exists := c.get(k)

--- a/common/cache.go
+++ b/common/cache.go
@@ -21,6 +21,7 @@ type clock func() time.Time
 // An element stored in the cache.
 type element struct {
 	expiration time.Time
+	timeout    time.Duration
 	value      Value
 }
 
@@ -85,7 +86,7 @@ func newCache(d time.Duration, initialSize int, l RemovalListener, t clock) *Cac
 // PutIfAbsent writes the given key and value to the cache only if the key is
 // absent from the cache. Nil is returned if the key-value pair were written,
 // otherwise the old value is returned.
-func (c *Cache) PutIfAbsent(k Key, v Value) Value {
+func (c *Cache) PutIfAbsent(k Key, v Value, timeout time.Duration) Value {
 	c.Lock()
 	defer c.Unlock()
 	oldValue, exists := c.get(k)
@@ -93,24 +94,24 @@ func (c *Cache) PutIfAbsent(k Key, v Value) Value {
 		return oldValue
 	}
 
-	c.put(k, v)
+	c.put(k, v, timeout)
 	return nil
 }
 
 // Put writes the given key and value to the map replacing any existing value
 // if it exists. The previous value associated with the key returned or nil
 // if the key was not present.
-func (c *Cache) Put(k Key, v Value) Value {
+func (c *Cache) Put(k Key, v Value, timeout time.Duration) Value {
 	c.Lock()
 	defer c.Unlock()
 	oldValue, _ := c.get(k)
-	c.put(k, v)
+	c.put(k, v, timeout)
 	return oldValue
 }
 
 // Replace overwrites the value for a key only if the key exists. The old
 // value is returned if the value is updated, otherwise nil is returned.
-func (c *Cache) Replace(k Key, v Value) Value {
+func (c *Cache) Replace(k Key, v Value, timeout time.Duration) Value {
 	c.Lock()
 	defer c.Unlock()
 	oldValue, exists := c.get(k)
@@ -118,7 +119,7 @@ func (c *Cache) Replace(k Key, v Value) Value {
 		return nil
 	}
 
-	c.put(k, v)
+	c.put(k, v, timeout)
 	return oldValue
 }
 
@@ -210,20 +211,24 @@ func (c *Cache) get(k Key) (Value, bool) {
 	elem, exists := c.elements[k]
 	now := c.clock()
 	if exists && !elem.IsExpired(now) {
-		elem.UpdateLastAccessTime(now, c.timeout)
+		elem.UpdateLastAccessTime(now, elem.timeout)
 		return elem.value, true
 	}
 	return nil, false
 }
 
 // put writes a key-value to the cache replacing any existing mapping.
-func (c *Cache) put(k Key, v Value) {
+func (c *Cache) put(k Key, v Value, timeout time.Duration) {
 	if v == nil {
 		panic("Cache does not support storing nil values.")
 	}
 
+	if timeout <= 0 {
+		timeout = c.timeout
+	}
 	c.elements[k] = &element{
-		expiration: c.clock().Add(c.timeout),
+		expiration: c.clock().Add(timeout),
+		timeout:    timeout,
 		value:      v,
 	}
 }

--- a/common/cache_test.go
+++ b/common/cache_test.go
@@ -42,7 +42,7 @@ func TestExpireWithRemovalListener(t *testing.T) {
 	callbackKey = nil
 	callbackValue = nil
 	c := newCache(Timeout, InitalSize, removalListener, fakeClock)
-	c.Put(alphaKey, alphaValue, 0)
+	c.Put(alphaKey, alphaValue)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
 	assert.Equal(t, 1, c.CleanUp())
 	assert.Equal(t, alphaKey, callbackKey)
@@ -52,30 +52,30 @@ func TestExpireWithRemovalListener(t *testing.T) {
 // Test that the number of removed elements is returned by Expire.
 func TestExpireWithoutRemovalListener(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue, 0)
-	c.Put(bravoKey, bravoValue, 0)
+	c.Put(alphaKey, alphaValue)
+	c.Put(bravoKey, bravoValue)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
 	assert.Equal(t, 2, c.CleanUp())
 }
 
 func TestPutIfAbsent(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	oldValue := c.PutIfAbsent(alphaKey, alphaValue, 0)
+	oldValue := c.PutIfAbsent(alphaKey, alphaValue)
 	assert.Nil(t, oldValue)
-	oldValue = c.PutIfAbsent(alphaKey, bravoValue, 0)
+	oldValue = c.PutIfAbsent(alphaKey, bravoValue)
 	assert.Equal(t, alphaValue, oldValue)
 }
 
 func TestPut(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	oldValue := c.Put(alphaKey, alphaValue, 0)
+	oldValue := c.Put(alphaKey, alphaValue)
 	assert.Nil(t, oldValue)
-	oldValue = c.Put(bravoKey, bravoValue, 0)
+	oldValue = c.Put(bravoKey, bravoValue)
 	assert.Nil(t, oldValue)
 
-	oldValue = c.Put(alphaKey, bravoValue, 0)
+	oldValue = c.Put(alphaKey, bravoValue)
 	assert.Equal(t, alphaValue, oldValue)
-	oldValue = c.Put(bravoKey, alphaValue, 0)
+	oldValue = c.Put(bravoKey, alphaValue)
 	assert.Equal(t, bravoValue, oldValue)
 }
 
@@ -83,18 +83,18 @@ func TestReplace(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
 
 	// Nil is returned when the value does not exist and no element is added.
-	assert.Nil(t, c.Replace(alphaKey, alphaValue, 0))
+	assert.Nil(t, c.Replace(alphaKey, alphaValue))
 	assert.Equal(t, 0, c.Size())
 
 	// alphaKey is replaced with the new value.
-	assert.Nil(t, c.Put(alphaKey, alphaValue, 0))
-	assert.Equal(t, alphaValue, c.Replace(alphaKey, bravoValue, 0))
+	assert.Nil(t, c.Put(alphaKey, alphaValue))
+	assert.Equal(t, alphaValue, c.Replace(alphaKey, bravoValue))
 	assert.Equal(t, 1, c.Size())
 }
 
 func TestGetUpdatesLastAccessTime(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue, 0)
+	c.Put(alphaKey, alphaValue)
 
 	currentTime = currentTime.Add(Timeout / 2)
 	assert.Equal(t, alphaValue, c.Get(alphaKey))
@@ -109,13 +109,13 @@ func TestDeleteNonExistentKey(t *testing.T) {
 
 func TestDeleteExistingKey(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue, 0)
+	c.Put(alphaKey, alphaValue)
 	assert.Equal(t, alphaValue, c.Delete(alphaKey))
 }
 
 func TestDeleteExpiredKey(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue, 0)
+	c.Put(alphaKey, alphaValue)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
 	assert.Nil(t, c.Delete(alphaKey))
 }
@@ -123,9 +123,9 @@ func TestDeleteExpiredKey(t *testing.T) {
 // Test that Entries returns the non-expired map entries.
 func TestEntries(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue, 0)
+	c.Put(alphaKey, alphaValue)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
-	c.Put(bravoKey, bravoValue, 0)
+	c.Put(bravoKey, bravoValue)
 	m := c.Entries()
 	assert.Equal(t, 1, len(m))
 	assert.Equal(t, bravoValue, m[bravoKey])
@@ -134,15 +134,15 @@ func TestEntries(t *testing.T) {
 // Test that Size returns a count of both expired and non-expired elements.
 func TestSize(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue, 0)
+	c.Put(alphaKey, alphaValue)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
-	c.Put(bravoKey, bravoValue, 0)
+	c.Put(bravoKey, bravoValue)
 	assert.Equal(t, 2, c.Size())
 }
 
 func TestGetExpiredValue(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue, 0)
+	c.Put(alphaKey, alphaValue)
 	v := c.Get(alphaKey)
 	assert.Equal(t, alphaValue, v)
 
@@ -158,7 +158,7 @@ func TestJanitor(t *testing.T) {
 	c := newCache(Timeout, InitalSize, func(k Key, v Value) {
 		keyChan <- k
 	}, fakeClock)
-	c.Put(alphaKey, alphaValue, 0)
+	c.Put(alphaKey, alphaValue)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
 	c.StartJanitor(time.Millisecond)
 	key := <-keyChan

--- a/common/cache_test.go
+++ b/common/cache_test.go
@@ -42,7 +42,7 @@ func TestExpireWithRemovalListener(t *testing.T) {
 	callbackKey = nil
 	callbackValue = nil
 	c := newCache(Timeout, InitalSize, removalListener, fakeClock)
-	c.Put(alphaKey, alphaValue)
+	c.Put(alphaKey, alphaValue, 0)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
 	assert.Equal(t, 1, c.CleanUp())
 	assert.Equal(t, alphaKey, callbackKey)
@@ -52,30 +52,30 @@ func TestExpireWithRemovalListener(t *testing.T) {
 // Test that the number of removed elements is returned by Expire.
 func TestExpireWithoutRemovalListener(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue)
-	c.Put(bravoKey, bravoValue)
+	c.Put(alphaKey, alphaValue, 0)
+	c.Put(bravoKey, bravoValue, 0)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
 	assert.Equal(t, 2, c.CleanUp())
 }
 
 func TestPutIfAbsent(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	oldValue := c.PutIfAbsent(alphaKey, alphaValue)
+	oldValue := c.PutIfAbsent(alphaKey, alphaValue, 0)
 	assert.Nil(t, oldValue)
-	oldValue = c.PutIfAbsent(alphaKey, bravoValue)
+	oldValue = c.PutIfAbsent(alphaKey, bravoValue, 0)
 	assert.Equal(t, alphaValue, oldValue)
 }
 
 func TestPut(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	oldValue := c.Put(alphaKey, alphaValue)
+	oldValue := c.Put(alphaKey, alphaValue, 0)
 	assert.Nil(t, oldValue)
-	oldValue = c.Put(bravoKey, bravoValue)
+	oldValue = c.Put(bravoKey, bravoValue, 0)
 	assert.Nil(t, oldValue)
 
-	oldValue = c.Put(alphaKey, bravoValue)
+	oldValue = c.Put(alphaKey, bravoValue, 0)
 	assert.Equal(t, alphaValue, oldValue)
-	oldValue = c.Put(bravoKey, alphaValue)
+	oldValue = c.Put(bravoKey, alphaValue, 0)
 	assert.Equal(t, bravoValue, oldValue)
 }
 
@@ -83,18 +83,18 @@ func TestReplace(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
 
 	// Nil is returned when the value does not exist and no element is added.
-	assert.Nil(t, c.Replace(alphaKey, alphaValue))
+	assert.Nil(t, c.Replace(alphaKey, alphaValue, 0))
 	assert.Equal(t, 0, c.Size())
 
 	// alphaKey is replaced with the new value.
-	assert.Nil(t, c.Put(alphaKey, alphaValue))
-	assert.Equal(t, alphaValue, c.Replace(alphaKey, bravoValue))
+	assert.Nil(t, c.Put(alphaKey, alphaValue, 0))
+	assert.Equal(t, alphaValue, c.Replace(alphaKey, bravoValue, 0))
 	assert.Equal(t, 1, c.Size())
 }
 
 func TestGetUpdatesLastAccessTime(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue)
+	c.Put(alphaKey, alphaValue, 0)
 
 	currentTime = currentTime.Add(Timeout / 2)
 	assert.Equal(t, alphaValue, c.Get(alphaKey))
@@ -109,13 +109,13 @@ func TestDeleteNonExistentKey(t *testing.T) {
 
 func TestDeleteExistingKey(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue)
+	c.Put(alphaKey, alphaValue, 0)
 	assert.Equal(t, alphaValue, c.Delete(alphaKey))
 }
 
 func TestDeleteExpiredKey(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue)
+	c.Put(alphaKey, alphaValue, 0)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
 	assert.Nil(t, c.Delete(alphaKey))
 }
@@ -123,9 +123,9 @@ func TestDeleteExpiredKey(t *testing.T) {
 // Test that Entries returns the non-expired map entries.
 func TestEntries(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue)
+	c.Put(alphaKey, alphaValue, 0)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
-	c.Put(bravoKey, bravoValue)
+	c.Put(bravoKey, bravoValue, 0)
 	m := c.Entries()
 	assert.Equal(t, 1, len(m))
 	assert.Equal(t, bravoValue, m[bravoKey])
@@ -134,15 +134,15 @@ func TestEntries(t *testing.T) {
 // Test that Size returns a count of both expired and non-expired elements.
 func TestSize(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue)
+	c.Put(alphaKey, alphaValue, 0)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
-	c.Put(bravoKey, bravoValue)
+	c.Put(bravoKey, bravoValue, 0)
 	assert.Equal(t, 2, c.Size())
 }
 
 func TestGetExpiredValue(t *testing.T) {
 	c := newCache(Timeout, InitalSize, nil, fakeClock)
-	c.Put(alphaKey, alphaValue)
+	c.Put(alphaKey, alphaValue, 0)
 	v := c.Get(alphaKey)
 	assert.Equal(t, alphaValue, v)
 
@@ -158,7 +158,7 @@ func TestJanitor(t *testing.T) {
 	c := newCache(Timeout, InitalSize, func(k Key, v Value) {
 		keyChan <- k
 	}, fakeClock)
-	c.Put(alphaKey, alphaValue)
+	c.Put(alphaKey, alphaValue, 0)
 	currentTime = currentTime.Add(Timeout).Add(time.Nanosecond)
 	c.StartJanitor(time.Millisecond)
 	key := <-keyChan


### PR DESCRIPTION
Configure per element timeout in cache. If element timeout is <=0, the
cache its default timeout will be used.

required for elastic/packetbeat#300