### PR TITLE
Add direction field to publisher output to indicate inbound/outbound transactions

### DIFF
--- a/publisher/preprocess.go
+++ b/publisher/preprocess.go
@@ -148,6 +148,15 @@ func updateEventAddresses(publisher *PublisherType, event common.MapStr) bool {
 		delete(event, "dst")
 	}
 
+	//get the direction of the transaction: outgoing (as client)/incoming (as server)
+	if (publisher.IsPublisherIP(dst.Ip)) {
+		// outgoing transaction
+		event["direction"] = "out"
+	} else {
+		//incoming transaction
+		event["direction"] = "in"
+	}
+
 	if publisher.IgnoreOutgoing && dstServer != "" &&
 		dstServer != publisher.name {
 		// duplicated transaction -> ignore it

--- a/publisher/publish.go
+++ b/publisher/publish.go
@@ -36,6 +36,7 @@ type TransactionalEventPublisher interface {
 
 type PublisherType struct {
 	name           string
+	ipaddrs        []string
 	tags           []string
 	disabled       bool
 	Index          string
@@ -85,6 +86,16 @@ func PrintPublishEvent(event common.MapStr) {
 	} else {
 		debug("Publish: %s", string(json))
 	}
+}
+
+func (publisher *PublisherType) IsPublisherIP(ip string) bool {
+	for _, myip := range publisher.ipaddrs {
+		if myip == ip {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (publisher *PublisherType) GetServerName(ip string) string {
@@ -224,6 +235,13 @@ func (publisher *PublisherType) Init(
 	}
 
 	publisher.tags = shipper.Tags
+
+	//Store the publisher's IP addresses
+	publisher.ipaddrs, err = common.LocalIpAddrsAsStrings(false)
+	if err != nil {
+		logp.Err("Failed to get local IP addresses: %s", err)
+		return err
+	}
 
 	if !publisher.disabled && publisher.TopologyOutput != nil {
 		RefreshTopologyFreq := 10 * time.Second


### PR DESCRIPTION
When ignore_outgoing is set to false, the outputs at the client and server are very similar, except for the response_time field. To clearly distinguish the direction of transaction (inbound or outbound), add a "direction" field to the publishers output.

Note that its very useful to set ignore_outgoing to false, when packetbeat is installed at both client and server, because (a) at the server side, the response_time field indicates the server's processing time for a given request, (b) at the client side, it provides the client observed response time of a transaction -- which includes Network RTT + server processing time. Subtracting client.response_time - server.response_time provides network RTT information.