### PR TITLE
fix elasticsearch host configuration address types

### DIFF
--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -67,7 +67,7 @@ func (out *elasticsearchOutput) Init(
 	if len(config.Hosts) > 0 {
 		// use hosts setting
 		for _, host := range config.Hosts {
-			url, err := getUrl(config.Protocol, config.Path, host)
+			url, err := getURL(config.Protocol, config.Path, host)
 
 			if err != nil {
 				logp.Err("Invalid host param set: %s, Error: %v", host, err)
@@ -292,63 +292,53 @@ func (out *elasticsearchOutput) BulkPublish(
 
 // Creates the url based on the url configuration.
 // Adds missing parts with defaults (scheme, host, port)
-func getUrl(defaultScheme string, defaultPath string, rawUrl string) (string, error) {
-
-	urlStruct, err := url.Parse(rawUrl)
-
+func getURL(defaultScheme string, defaultPath string, rawURL string) (string, error) {
+	addr, err := url.Parse(rawURL)
 	if err != nil {
 		return "", err
 	}
 
-	host := ""
-	port := ""
+	scheme := addr.Scheme
+	host := addr.Host
+	port := "9200"
 
-	// If url doesn't have a scheme, host is written into path. For example: 192.168.3.7
-	if urlStruct.Host == "" {
-		urlStruct.Host = urlStruct.Path
-		urlStruct.Path = ""
+	// sanitize parse errors if url does not contain scheme :/
+	switch {
+	case addr.Scheme == "":
+		// If url doesn't have a scheme, host is written into path. For example: 192.168.3.7
+		scheme = defaultScheme
+		host = addr.Path
+		addr.Path = ""
+	case addr.Host == "" && addr.Path == "" && addr.Opaque != "":
+		// if host and path empty, url only contains ':' but no schema.
+		// Port is written to opaque
+		scheme = defaultScheme
+		host = rawURL
+		addr.Opaque = ""
 	}
 
-	// Checks if split host works
-	_, _, err = net.SplitHostPort(urlStruct.Host)
-
-	// Only does split host if no errors
-	if err == nil {
-		host, port, err = net.SplitHostPort(urlStruct.Host)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		host = urlStruct.Host
-	}
-
-	// Assign default host if not set
 	if host == "" {
 		host = "localhost"
-	}
+	} else {
+		// split host and optional port
+		if splitHost, splitPort, err := net.SplitHostPort(host); err == nil {
+			host = splitHost
+			port = splitPort
+		}
 
-	// Assign default port if not set
-	if port == "" {
-		port = "9200"
-	}
-
-	// Assign default scheme if not set
-	if urlStruct.Scheme == "" {
-		urlStruct.Scheme = defaultScheme
+		// Check if ipv6
+		if strings.Count(host, ":") > 1 && strings.Count(host, "]") == 0 {
+			host = "[" + host + "]"
+		}
 	}
 
 	// Assign default path if not set
-	if urlStruct.Path == "" {
-		urlStruct.Path = defaultPath
+	if addr.Path == "" {
+		addr.Path = defaultPath
 	}
 
-	// Check if ipv6
-	if strings.Count(host, ":") > 1 && strings.Count(host, "]") == 0 {
-		host = "[" + host + "]"
-	}
-
-	urlStruct.Host = host + ":" + port
-
-	return urlStruct.String(), nil
-
+	// reconstruct url
+	addr.Scheme = scheme
+	addr.Host = host + ":" + port
+	return addr.String(), nil
 }

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -339,38 +339,54 @@ func TestGetUrl(t *testing.T) {
 	// Setting a path without a scheme is not allowed. Example: 192.168.1.1:9200/hello
 	inputOutput := map[string]string{
 		// shema + hostname
-		"":                  "http://localhost:9200",
-		"http://localhost":  "http://localhost:9200",
-		"http://localhost/": "http://localhost:9200/",
+		"":                     "http://localhost:9200",
+		"http://localhost":     "http://localhost:9200",
+		"http://localhost:80":  "http://localhost:80",
+		"http://localhost:80/": "http://localhost:80/",
+		"http://localhost/":    "http://localhost:9200/",
 
 		// no schema + hostname
-		"localhost":      "http://localhost:9200",
-		"localhost:1234": "http://localhost:1234",
+		"localhost":        "http://localhost:9200",
+		"localhost:80":     "http://localhost:80",
+		"localhost:80/":    "http://localhost:80/",
+		"localhost/":       "http://localhost:9200/",
+		"localhost/mypath": "http://localhost:9200/mypath",
 
 		// shema + ipv4
-		"http://192.168.1.1:9200":  "http://192.168.1.1:9200",
-		"https://192.168.1.1:9200": "https://192.168.1.1:9200",
-		"http://192.168.1.1":       "http://192.168.1.1:9200",
-		"http://192.168.1.1/hello": "http://192.168.1.1:9200/hello",
+		"http://192.168.1.1:80":        "http://192.168.1.1:80",
+		"https://192.168.1.1:80/hello": "https://192.168.1.1:80/hello",
+		"http://192.168.1.1":           "http://192.168.1.1:9200",
+		"http://192.168.1.1/hello":     "http://192.168.1.1:9200/hello",
 
 		// no schema + ipv4
-		"192.168.1.1":      "http://192.168.1.1:9200",
-		"192.168.1.1:9200": "http://192.168.1.1:9200",
+		"192.168.1.1":          "http://192.168.1.1:9200",
+		"192.168.1.1:80":       "http://192.168.1.1:80",
+		"192.168.1.1/hello":    "http://192.168.1.1:9200/hello",
+		"192.168.1.1:80/hello": "http://192.168.1.1:80/hello",
 
 		// schema + ipv6
-		"http://[2001:db8::1]:80":                        "http://[2001:db8::1]:80",
-		"http://[2001:db8::1]":                           "http://[2001:db8::1]:9200",
-		"https://[2001:db8::1]:9200":                     "https://[2001:db8::1]:9200",
-		"http://FE80:0000:0000:0000:0202:B3FF:FE1E:8329": "http://[FE80:0000:0000:0000:0202:B3FF:FE1E:8329]:9200",
+		"http://[2001:db8::1]:80":                              "http://[2001:db8::1]:80",
+		"http://[2001:db8::1]":                                 "http://[2001:db8::1]:9200",
+		"https://[2001:db8::1]:9200":                           "https://[2001:db8::1]:9200",
+		"http://FE80:0000:0000:0000:0202:B3FF:FE1E:8329":       "http://[FE80:0000:0000:0000:0202:B3FF:FE1E:8329]:9200",
+		"http://[2001:db8::1]:80/hello":                        "http://[2001:db8::1]:80/hello",
+		"http://[2001:db8::1]/hello":                           "http://[2001:db8::1]:9200/hello",
+		"https://[2001:db8::1]:9200/hello":                     "https://[2001:db8::1]:9200/hello",
+		"http://FE80:0000:0000:0000:0202:B3FF:FE1E:8329/hello": "http://[FE80:0000:0000:0000:0202:B3FF:FE1E:8329]:9200/hello",
 
 		// no schema + ipv6
-		"[2001:db8::1]:80": "http://[2001:db8::1]:80",
+		"2001:db8::1":            "http://[2001:db8::1]:9200",
+		"[2001:db8::1]:80":       "http://[2001:db8::1]:80",
+		"[2001:db8::1]":          "http://[2001:db8::1]:9200",
+		"2001:db8::1/hello":      "http://[2001:db8::1]:9200/hello",
+		"[2001:db8::1]:80/hello": "http://[2001:db8::1]:80/hello",
+		"[2001:db8::1]/hello":    "http://[2001:db8::1]:9200/hello",
 	}
 
 	for input, output := range inputOutput {
 		urlNew, err := getURL("http", "", input)
 		assert.Nil(t, err)
-		assert.Equal(t, output, urlNew)
+		assert.Equal(t, output, urlNew, fmt.Sprintf("input: %v", input))
 	}
 
 	inputOutputWithDefaults := map[string]string{

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -338,25 +338,37 @@ func TestGetUrl(t *testing.T) {
 	// List of inputs / outputs that must match after fetching url
 	// Setting a path without a scheme is not allowed. Example: 192.168.1.1:9200/hello
 	inputOutput := map[string]string{
-		"":                         "http://localhost:9200",
-		"http://localhost":         "http://localhost:9200",
-		"http://localhost/":        "http://localhost:9200/",
+		// shema + hostname
+		"":                  "http://localhost:9200",
+		"http://localhost":  "http://localhost:9200",
+		"http://localhost/": "http://localhost:9200/",
+
+		// no schema + hostname
+		"localhost":      "http://localhost:9200",
+		"localhost:1234": "http://localhost:1234",
+
+		// shema + ipv4
 		"http://192.168.1.1:9200":  "http://192.168.1.1:9200",
 		"https://192.168.1.1:9200": "https://192.168.1.1:9200",
 		"http://192.168.1.1":       "http://192.168.1.1:9200",
 		"http://192.168.1.1/hello": "http://192.168.1.1:9200/hello",
-		"192.168.1.1":              "http://192.168.1.1:9200",
-		"192.168.1.1:9200":         "http://192.168.1.1:9200",
-		// IPv6 addresses
-		"[2001:db8::1]:80":                               "http://[2001:db8::1]:80",
+
+		// no schema + ipv4
+		"192.168.1.1":      "http://192.168.1.1:9200",
+		"192.168.1.1:9200": "http://192.168.1.1:9200",
+
+		// schema + ipv6
 		"http://[2001:db8::1]:80":                        "http://[2001:db8::1]:80",
 		"http://[2001:db8::1]":                           "http://[2001:db8::1]:9200",
 		"https://[2001:db8::1]:9200":                     "https://[2001:db8::1]:9200",
 		"http://FE80:0000:0000:0000:0202:B3FF:FE1E:8329": "http://[FE80:0000:0000:0000:0202:B3FF:FE1E:8329]:9200",
+
+		// no schema + ipv6
+		"[2001:db8::1]:80": "http://[2001:db8::1]:80",
 	}
 
 	for input, output := range inputOutput {
-		urlNew, err := getUrl("http", "", input)
+		urlNew, err := getURL("http", "", input)
 		assert.Nil(t, err)
 		assert.Equal(t, output, urlNew)
 	}
@@ -367,7 +379,7 @@ func TestGetUrl(t *testing.T) {
 		"http://username:password@es.found.io:9324": "http://username:password@es.found.io:9324/hello",
 	}
 	for input, output := range inputOutputWithDefaults {
-		urlNew, err := getUrl("https", "/hello", input)
+		urlNew, err := getURL("https", "/hello", input)
 		assert.Nil(t, err)
 		assert.Equal(t, output, urlNew)
 	}


### PR DESCRIPTION
fixes #142

This PR adds some more possible address types to the unit tests and fixes parsing by retrying on weird parse results by prepending scheme to given address.