### PR TITLE
Update tls config options naming

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -628,9 +628,9 @@ is 7 files.
 
 When set to true none of the TLS configuration options will be applied. Effect is similar to missing TLS configuration in output plugin.
 
-===== certificate-authorities
+===== certificate_authorities
 
-List of root certificates for server verifications. If certificate-authorities is empty or not set, the trusted certificate authorities of the host system will be employed.
+List of root certificates for server verifications. If certificate_authorities is empty or not set, the trusted certificate authorities of the host system will be employed.
 
 ===== certificate: "/etc/pki/client/cert.pem"
 
@@ -640,15 +640,15 @@ may fail if server requests client authentication. If TLS server does not
 require client authentication, the certificate will be loaded but not be
 requested/used by server.
 
-When configured, both certificate and certificate-key options are required.
+When configured, both certificate and certificate_key options are required.
 
-===== certificate-key: "/etc/pki/client/cert.key"
+===== certificate_key: "/etc/pki/client/cert.key"
 
 Client certificate key required to configure certificate for client
 authentication. If certificate is not configured, client authentication is
 not available in client.
 
-When configured, both certificate and certificate-key are required.
+When configured, both certificate and certificate_key are required.
 
 ===== insecure
 
@@ -657,9 +657,9 @@ If insecure is set to true, all server host names and certificates will be
 accepted. In this mode TLS based connections are susceptible to
 man-in-the-middle attacks. Use only for testing.
 
-===== cipher-suites
+===== cipher_suites
 
-Configure list of used cipher suites. First entry has highest priority. If cipher-suites config option is missing, the go crypto library its default suites configuration is used(recommended).
+Configure list of used cipher suites. First entry has highest priority. If cipher_suites config option is missing, the go crypto library its default suites configuration is used(recommended).
 
 
 List of allowed cipher suites names and their meanings.
@@ -709,7 +709,7 @@ The following cipher suites are available:
 * ECDHE-RSA-AES256-GCM-SHA384 (TLS 1.2 only)
 * ECDHE-ECDSA-AES256-GCM-SHA384 (TLS 1.2 only)
 
-===== curve-types
+===== curve_types
 
 Configure available curve types for ECDHE (Elliptic Curve Diffie-Hellman ephemeral key exchange).
 

--- a/etc/libbeat.yml
+++ b/etc/libbeat.yml
@@ -63,13 +63,13 @@ output:
       #disabled: true
 
       # List of root certificates for HTTPS server verifications
-      #certificate-authorities: ["/etc/pki/root/ca.pem"]
+      #certificate_authorities: ["/etc/pki/root/ca.pem"]
 
       # Certificate for TLS client authentication
       #certificate: "/etc/pki/client/cert.pem"
 
       # Client Certificate Key
-      #certificate-key: "/etc/pki/client/cert.key"
+      #certificate_key: "/etc/pki/client/cert.key"
 
       # Controls whether the client verifies server certificates and host name.
       # If insecure is set to true, all server host names and certificates will be
@@ -78,10 +78,10 @@ output:
       #insecure: true
 
       # Configure cipher suites to be used for TLS connections
-      #cipher-suites: []
+      #cipher_suites: []
 
       # Configure curve types for ECDHE based cipher suites
-      #curve-types: []
+      #curve_types: []
 
 
   ### Redis as output

--- a/outputs/tls.go
+++ b/outputs/tls.go
@@ -34,13 +34,13 @@ var (
 type TLSConfig struct {
 	Disabled       bool     `yaml:"disabled"`
 	Certificate    string   `yaml:"certificate"`
-	CertificateKey string   `yaml:"certificate-key"`
-	CAs            []string `yaml:"certificate-authorities"`
+	CertificateKey string   `yaml:"certificate_key"`
+	CAs            []string `yaml:"certificate_authorities"`
 	Insecure       bool     `yaml:"insecure,omitempty"`
-	CipherSuites   []string `yaml:"cipher-suites"`
-	MinVersion     string   `yaml:"min-version,omitempty"`
-	MaxVersion     string   `yaml:"max-version,omitempty"`
-	CurveTypes     []string `yaml:"curve-types"`
+	CipherSuites   []string `yaml:"cipher_suites"`
+	MinVersion     string   `yaml:"min_version,omitempty"`
+	MaxVersion     string   `yaml:"max_version,omitempty"`
+	CurveTypes     []string `yaml:"curve_types"`
 }
 
 // LoadTLSConfig will load a certificate from config with all TLS based keys

--- a/outputs/tls_test.go
+++ b/outputs/tls_test.go
@@ -64,15 +64,15 @@ func TestValuesSet(t *testing.T) {
 	cfg, err := load(`
     disabled: true
     certificate: mycert.pem
-    certificate-key: mycert.key
-    certificate-authorities: ["ca1.pem", "ca2.pem"]
+    certificate_key: mycert.key
+    certificate_authorities: ["ca1.pem", "ca2.pem"]
     insecure: true
-    cipher-suites:
+    cipher_suites:
       - ECDHE-ECDSA-AES-256-CBC-SHA
       - ECDHE-ECDSA-AES-256-GCM-SHA384
-    min-version: 1.1
-    max-version: 1.2
-    curve-types:
+    min_version: 1.1
+    max_version: 1.2
+    curve_types:
       - P-521
   `)
 


### PR DESCRIPTION
Use underscore in tls yaml config options to be consistent with other options.