### PR TITLE
Update to elasticsearch 1.7.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
 
 env:
   - TARGETS="check"
-  - TARGETS="testsuite ES_HOST=elasticsearch-172"
+  - TARGETS="testsuite ES_HOST=elasticsearch-173"
   - TARGETS="testsuite ES_HOST=elasticsearch-200"
   - TARGETS="crosscompile"
 

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ build-image: write-environment
 # To use it for running the test, set ES_HOST and REDIS_HOST environment variable to the ip of your docker-machine.
 .PHONY: start-environment
 start-environment: stop-environment
-	docker-compose up -d redis elasticsearch-172 elasticsearch-200 logstash
+	docker-compose up -d redis elasticsearch-173 elasticsearch-200 logstash
 
 .PHONY: stop-environment
 stop-environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ libbeat:
   build: .
   links:
     - redis
-    - elasticsearch-172
+    - elasticsearch-173
     - elasticsearch-200
     - logstash
   environment:
@@ -12,8 +12,8 @@ libbeat:
     - LS_TCP_PORT=12345
   env_file:
     - build/test.env
-elasticsearch-172:
-  image: elasticsearch:1.7.2
+elasticsearch-173:
+  image: elasticsearch:1.7.3
 elasticsearch-200:
   image: elasticsearch:2.0.0-rc1
   command: elasticsearch -Des.network.host=0.0.0.0
@@ -24,5 +24,5 @@ logstash:
   env_file:
     - build/test.env
   links:
-    - elasticsearch-172
+    - elasticsearch-173
     - elasticsearch-200

--- a/outputs/elasticsearch/connection_pool_test.go
+++ b/outputs/elasticsearch/connection_pool_test.go
@@ -88,7 +88,7 @@ func TestDeadTimeout(t *testing.T) {
 	assertExpectedConnectionURL(t, conn.URL, urls[0])
 
 	pool.MarkDead(conn)
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	assertExpectedConnectionURL(t, pool.GetConnection().URL, urls[1])
 	assertExpectedConnectionURL(t, pool.GetConnection().URL, urls[0])


### PR DESCRIPTION
Updates the 1.X version of ES used for integration testing. I also increased the sleep in `TestDeadTimeout` in hopes that it will increase the stability of the tests.