### PR TITLE
Update elasticsearch to version 1.7.3 and beat dashboards to beta4

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,8 +1,8 @@
 [[beats-reference]]
 = Beats Platform Reference
-:ES-version: 1.7.2
+:ES-version: 1.7.3
 :Kibana-version: 4.1.2
-:Dashboards-version: 1.0.0-beta3
+:Dashboards-version: 1.0.0-beta4
 
 include::./overview.asciidoc[]
 


### PR DESCRIPTION
For this to work, the new dashboards must be first uploaded under http://download.elastic.co/beats/dashboards/beats-dashboards-1.0.0-beta4.tar.gz