### PR TITLE
Mark Redis Output deprecated in the code

### DIFF
--- a/outputs/redis/redis.go
+++ b/outputs/redis/redis.go
@@ -1,3 +1,6 @@
+// Starting with version 1.0.0-beta4 the Redis Output is deprecated as
+// it's replaced by the Logstash Output that has support for Redis Output plugin.
+
 package redis
 
 import (
@@ -16,6 +19,7 @@ import (
 )
 
 func init() {
+
 	outputs.RegisterOutputPlugin("redis", RedisOutputPlugin{})
 }
 
@@ -65,6 +69,8 @@ type message struct {
 }
 
 func (out *redisOutput) Init(beat string, config outputs.MothershipConfig, topology_expire int) error {
+
+	logp.Warn("Redis Output is deprecated. Please use the Redis Output Plugin from Logstash instead.")
 
 	out.Hostname = fmt.Sprintf("%s:%d", config.Host, config.Port)
 

--- a/outputs/redis/redis.go
+++ b/outputs/redis/redis.go
@@ -1,4 +1,4 @@
-// Starting with version 1.0.0-beta4 the Redis Output is deprecated as
+//@deprecated: Starting with version 1.0.0-beta4 the Redis Output is deprecated as
 // it's replaced by the Logstash Output that has support for Redis Output plugin.
 
 package redis


### PR DESCRIPTION
Add a warning message when using the redis output