### PR TITLE
Publisher Preprocessor Logic Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file based on the
 ### Backward Compatibility Breaks
 
 ### Bugfixes
+- Handle empty event array in publisher. #207
 
 ### Added
 

--- a/publisher/preprocess.go
+++ b/publisher/preprocess.go
@@ -27,7 +27,7 @@ func (p *preprocessor) onMessage(m message) {
 	publisher := p.pub
 	single := false
 	events := m.events
-	if events == nil {
+	if m.event != nil {
 		single = true
 		events = []common.MapStr{m.event}
 	}


### PR DESCRIPTION
Change logic used by the publisher's preprocessor for determining whether to use `message.event` or `message.events`. This change allows the preprocessor to function correctly in the case that a client publishes an empty message.events. It also makes the logic consistent with other parts of the code like bulk.go.

I discovered that if I sent an empty events slice that the processor would complain about a `"Missing 'timestamp' field from event"` because it tried to send `message.event`.