### PR TITLE
Add logging messages for bulk publishing in case of error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file based on the
 - Send @metadata.beat to Logstash instead of @metadata.index to prevent
   possible name clashes and give user full control over index name used for
   Elasticsearch
+- Add logging messages for bulk publishing in case of error #229
 
 ### Deprecated
 

--- a/outputs/console/console.go
+++ b/outputs/console/console.go
@@ -75,7 +75,6 @@ func (c *console) PublishEvent(
 	outputs.SignalCompleted(s)
 	return nil
 fail:
-	logp.Err("Fail to write event: %s", err)
-	outputs.SignalFailed(s)
+	outputs.SignalFailed(s, err)
 	return err
 }

--- a/outputs/redis/redis.go
+++ b/outputs/redis/redis.go
@@ -300,7 +300,7 @@ func (out *redisOutput) BulkPublish(
 		}
 		err = out.Conn.Send(command, out.Index, string(jsonEvent))
 		if err != nil {
-			outputs.SignalFailed(signal)
+			outputs.SignalFailed(signal, err)
 			out.onFail(err)
 			return err
 		}

--- a/outputs/signal.go
+++ b/outputs/signal.go
@@ -1,6 +1,7 @@
 package outputs
 
 import (
+	"github.com/elastic/libbeat/logp"
 	"sync/atomic"
 )
 
@@ -140,7 +141,12 @@ func SignalCompleted(s Signaler) {
 }
 
 // SignalFailed sends the Failed event to s if s is not nil
-func SignalFailed(s Signaler) {
+func SignalFailed(s Signaler, err error) {
+
+	if err != nil {
+		logp.Err("Error sending/writing event: %s", err)
+	}
+
 	if s != nil {
 		s.Failed()
 	}
@@ -149,6 +155,11 @@ func SignalFailed(s Signaler) {
 // Signal will send the Completed or Failed event to s depending
 // on err being set if s is not nil.
 func Signal(s Signaler, err error) {
+
+	if err != nil {
+		logp.Info("Failed to send event %s", err)
+	}
+
 	if s != nil {
 		if err == nil {
 			s.Completed()

--- a/publisher/common_test.go
+++ b/publisher/common_test.go
@@ -37,7 +37,7 @@ func (mh *testMessageHandler) acknowledgeMessage(m message) {
 	if mh.response == CompletedResponse {
 		outputs.SignalCompleted(m.signal)
 	} else {
-		outputs.SignalFailed(m.signal)
+		outputs.SignalFailed(m.signal, nil)
 	}
 }
 

--- a/publisher/output.go
+++ b/publisher/output.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/elastic/libbeat/common"
+	"github.com/elastic/libbeat/logp"
 	"github.com/elastic/libbeat/outputs"
 )
 
@@ -41,6 +42,10 @@ func (o *outputWorker) onMessage(m message) {
 
 		debug("output worker: publish %v events", len(m.events))
 		ts := time.Time(m.events[0]["timestamp"].(common.Time)).UTC()
-		_ = o.out.BulkPublish(m.signal, ts, m.events)
+		err := o.out.BulkPublish(m.signal, ts, m.events)
+
+		if err != nil {
+			logp.Info("Error bulk publishing events: %s", err)
+		}
 	}
 }

--- a/publisher/worker.go
+++ b/publisher/worker.go
@@ -87,6 +87,6 @@ func (ws *workerSignal) Init() {
 func stopQueue(qu chan message) {
 	close(qu)
 	for msg := range qu { // clear queue and send fail signal
-		outputs.SignalFailed(msg.signal)
+		outputs.SignalFailed(msg.signal, nil)
 	}
 }


### PR DESCRIPTION
The goal here is to make it easier to spot problems with bulk publishing. This should users help to better understand what is going on.

@urso Have a look to see if this make sense from your perspective. I think the most important one to log is form BulkPublish as we just skipped the error so far.