### PR TITLE
Configure number of workers in ES/LS outputer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file based on the
 - Handle empty event array in publisher. #207
 - Limit number of workers for Elasticsearch output to 1 per configured host. packetbeat#226
 - Respect '*' debug selector in IsDebug. #226 (elastic/packetbeat#339)
+- Limit number of workers for Elasticsearch output. elastic/packetbeat#226
 
 ### Added
 - Add Console output plugin. #218
@@ -20,6 +21,8 @@ All notable changes to this project will be documented in this file based on the
   possible name clashes and give user full control over index name used for
   Elasticsearch
 - Add logging messages for bulk publishing in case of error #229
+- Add option to configure number of parallel workers publishing to Elasticsearch
+  or Logstash.
 
 ### Deprecated
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -291,6 +291,11 @@ output:
 In the previous example, the Elasticsearch nodes are available at https://10.45.3.2:9220/elasticsearch and
 https://10.45.3.1:9230/elasticsearch.
 
+===== worker
+
+Number of workers per configured host publishing events to Elasticsearch. This
+is best used with load balancing mode enabled. Example: If you have 2 hosts and
+3 workers, in total 6 workers are started (3 for each host).
 
 ===== host (DEPRECATED)
 
@@ -465,6 +470,12 @@ Boolean option that enables logstash output. The default is true.
 List of known logstash servers to connect to. All entries in this list can
 contain a port number. If no port number is given, the port options value is
 used as default port number.
+
+===== worker
+
+Number of workers per configured host publishing events to Logstash. This
+is best used with load balancing mode enabled. Example: If you have 2 hosts and
+3 workers, in total 6 workers are started (3 for each host).
 
 [[loadbalance]]
 ===== loadbalance

--- a/etc/libbeat.yml
+++ b/etc/libbeat.yml
@@ -23,6 +23,9 @@ output:
     #username: "admin"
     #password: "s3cr3t"
 
+    # Number of workers per Elasticsearch host.
+    #worker: 1
+
     # Elasticsearch. The default is false.
     # This option makes sense only for Packetbeat
     #save_topology: false
@@ -97,6 +100,9 @@ output:
 
     # The Logstash hosts
     #hosts: ["localhost:5044", "logstash:5045"]
+
+    # Number of workers per Logstash host.
+    #worker: 1
 
     # Optional load balance the events between the Logstash hosts
     #loadbalance: true

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -1,8 +1,8 @@
 package elasticsearch
 
 import (
+	"crypto/tls"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/elastic/libbeat/common"
@@ -14,9 +14,6 @@ import (
 var debug = logp.MakeDebug("elasticsearch")
 
 var (
-	// ErrNoHostsConfigured indicates missing host or hosts configuration
-	ErrNoHostsConfigured = errors.New("no host configuration found")
-
 	// ErrNotConnected indicates failure due to client having no valid connection
 	ErrNotConnected = errors.New("not connected")
 
@@ -64,7 +61,12 @@ func (out *elasticsearchOutput) init(
 	config outputs.MothershipConfig,
 	topologyExpire int,
 ) error {
-	clients, err := makeClients(beat, config)
+	tlsConfig, err := outputs.LoadTLSConfig(config.TLS)
+	if err != nil {
+		return err
+	}
+
+	clients, err := mode.MakeClients(config, makeClientFactory(beat, tlsConfig, config))
 	if err != nil {
 		return err
 	}
@@ -130,43 +132,26 @@ func (out *elasticsearchOutput) init(
 	return nil
 }
 
-func makeClients(
+func makeClientFactory(
 	beat string,
+	tls *tls.Config,
 	config outputs.MothershipConfig,
-) ([]mode.ProtocolClient, error) {
-	var urls []string
-	if len(config.Hosts) > 0 {
-		// use hosts setting
-		for _, host := range config.Hosts {
-			url, err := getURL(config.Protocol, config.Path, host)
-			if err != nil {
-				logp.Err("Invalid host param set: %s, Error: %v", host, err)
-			}
-
-			urls = append(urls, url)
+) func(string) (mode.ProtocolClient, error) {
+	return func(host string) (mode.ProtocolClient, error) {
+		url, err := getURL(config.Protocol, config.Path, host)
+		if err != nil {
+			logp.Err("Invalid host param set: %s, Error: %v", host, err)
+			return nil, err
 		}
-	} else {
-		// usage of host and port is deprecated as it is replaced by hosts
-		url := fmt.Sprintf("%s://%s:%d%s", config.Protocol, config.Host, config.Port, config.Path)
-		urls = append(urls, url)
-	}
 
-	index := beat
-	if config.Index != "" {
-		index = config.Index
-	}
+		index := beat
+		if config.Index != "" {
+			index = config.Index
+		}
 
-	tlsConfig, err := outputs.LoadTLSConfig(config.TLS)
-	if err != nil {
-		return nil, err
+		client := NewClient(url, index, tls, config.Username, config.Password)
+		return client, nil
 	}
-
-	var clients []mode.ProtocolClient
-	for _, url := range urls {
-		client := NewClient(url, index, tlsConfig, config.Username, config.Password)
-		clients = append(clients, client)
-	}
-	return clients, nil
 }
 
 func (out *elasticsearchOutput) PublishEvent(

--- a/outputs/logstash/logstash.go
+++ b/outputs/logstash/logstash.go
@@ -5,7 +5,6 @@ package logstash
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"time"
 
@@ -48,9 +47,6 @@ const (
 	defaultSendRetries     = 3
 )
 
-// ErrNoHostsConfigured indicates missing host or hosts configuration
-var ErrNoHostsConfigured = errors.New("no host configuration found")
-
 var waitRetry = time.Duration(1) * time.Second
 
 func (lj *logstash) init(
@@ -82,15 +78,15 @@ func (lj *logstash) init(
 			return err
 		}
 
-		clients, err = makeClients(config, timeout,
+		clients, err = mode.MakeClients(config, makeClientFactory(timeout,
 			func(host string) (TransportClient, error) {
 				return newTLSClient(host, defaultPort, tlsConfig)
-			})
+			}))
 	} else {
-		clients, err = makeClients(config, timeout,
+		clients, err = mode.MakeClients(config, makeClientFactory(timeout,
 			func(host string) (TransportClient, error) {
 				return newTCPClient(host, defaultPort)
-			})
+			}))
 	}
 	if err != nil {
 		return err
@@ -126,34 +122,16 @@ func (lj *logstash) init(
 	return nil
 }
 
-func makeClients(
-	config outputs.MothershipConfig,
+func makeClientFactory(
 	timeout time.Duration,
-	newTransp func(string) (TransportClient, error),
-) ([]mode.ProtocolClient, error) {
-	switch {
-	case len(config.Hosts) > 0:
-		var clients []mode.ProtocolClient
-		for _, host := range config.Hosts {
-			transp, err := newTransp(host)
-			if err != nil {
-				for _, client := range clients {
-					_ = client.Close() // ignore error
-				}
-				return nil, err
-			}
-			client := newLumberjackClient(transp, timeout)
-			clients = append(clients, client)
-		}
-		return clients, nil
-	case config.Host != "":
-		transp, err := newTransp(config.Host)
+	makeTransp func(string) (TransportClient, error),
+) func(string) (mode.ProtocolClient, error) {
+	return func(host string) (mode.ProtocolClient, error) {
+		transp, err := makeTransp(host)
 		if err != nil {
 			return nil, err
 		}
-		return []mode.ProtocolClient{newLumberjackClient(transp, timeout)}, nil
-	default:
-		return nil, ErrNoHostsConfigured
+		return newLumberjackClient(transp, timeout), nil
 	}
 }
 

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -32,6 +32,7 @@ type MothershipConfig struct {
 	Max_retries        *int
 	Pretty             *bool
 	TLS                *TLSConfig
+	Worker             int
 }
 
 type Outputer interface {


### PR DESCRIPTION
configure number of workers per Host to be used by loadbalancing mode via
'worker' option