### PR TITLE
fail bulk request if an item index failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 - Use stderr for console log output. #219
 - Handle empty event array in publisher. #207
-- Limit number of workers for Elasticsearch output to 1 per configured host. packetbeat#226
 - Respect '*' debug selector in IsDebug. #226 (elastic/packetbeat#339)
 - Limit number of workers for Elasticsearch output. elastic/packetbeat#226
 - On Windows, remove service related error message when running in the console. #242
 - Fix waitRetry no configured in single output mode configuration. elastic/filebeat#144
 - Use http as the default scheme in the elasticsearch hosts #253
+- Respect max bulk size if bulk publisher (collector) is disabled or sync flag is set.
+- Always evaluate status code from Elasticsearch responses when indexing events. #192
 
 ### Added
 - Add Console output plugin. #218
@@ -27,6 +28,10 @@ All notable changes to this project will be documented in this file based on the
 - Add logging messages for bulk publishing in case of error #229
 - Add option to configure number of parallel workers publishing to Elasticsearch
   or Logstash.
+- Set default bulk size for Elasticsearch output to 50.
+- Set default http timeout for Elasticsearch to 90s.
+- Improve publish retry if sync flag is set by retrying only up to max bulk size
+  events instead of all events to be published.
 
 ### Deprecated
 
@@ -40,8 +45,9 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 - Determine Elasticsearch index for an event based on UTC time #81
 - Fixing ES output's defaultDeadTimeout so that it is 60 seconds #103
-- Es outputer: fix timestamp conversion #91
+- ES outputer: fix timestamp conversion #91
 - Fix TLS insecure config option #239
+- ES outputer: check bulk API per item status code for retransmit on failure.
 
 ### Added
 - Add logstash output plugin #151

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -305,7 +305,6 @@ The host of the Elasticsearch server. This option is deprecated as it is replace
 
 The port of the Elasticsearch server. This option is deprecated as it is replaced by <<hosts-option>>.
 
-
 ===== username
 
 Basic authentication username for connecting to Elasticsearch.
@@ -327,7 +326,6 @@ An HTTP path prefix that is prepended to the HTTP API calls. This is useful for
 the cases where Elasticsearch listens behind an HTTP reverse proxy that exports
 the API under a custom prefix.
 
-
 ===== index
 
 The index root name where to write events to. The default is `packetbeat` and
@@ -335,7 +333,6 @@ generates `[packetbeat-]YYYY.MM.DD` indexes (e.g. `packetbeat-2015.04.26`).
 
 The index root name where to write events to. The default is the beat its name.
 For example `packetbeat` generates `[packetbeat-]YYYY.MM.DD` indexes (e.g. `packetbeat-2015.04.26`).
-
 
 ===== max_retries
 
@@ -346,7 +343,11 @@ dropped. The default is 3.
 ===== bulk_max_size
 
 The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-The default is 10000.
+The default is 50.
+
+===== timeout
+
+The http request timeout in seconds for Elasticsearch request. The default is 90.
 
 ===== flush_interval
 

--- a/etc/libbeat.yml
+++ b/etc/libbeat.yml
@@ -43,8 +43,11 @@ output:
     #max_retries: 3
 
     # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-    # The default is 10000.
-    #bulk_max_size: 10000
+    # The default is 50.
+    #bulk_max_size: 50
+
+    # Configure http request timeout before failing an request to Elasticsearch.
+    #timeout: 90
 
     # The number of seconds to wait for new events between two bulk API index requests.
     # If `bulk_max_size` is reached before this interval expires, addition bulk index

--- a/outputs/elasticsearch/api_integration_test.go
+++ b/outputs/elasticsearch/api_integration_test.go
@@ -30,7 +30,7 @@ func TestIndex(t *testing.T) {
 	params := map[string]string{
 		"refresh": "true",
 	}
-	resp, err := client.Index(index, "test", "1", params, body)
+	_, resp, err := client.Index(index, "test", "1", params, body)
 	if err != nil {
 		t.Errorf("Index() returns error: %s", err)
 	}
@@ -41,7 +41,7 @@ func TestIndex(t *testing.T) {
 	params = map[string]string{
 		"q": "user:test",
 	}
-	result, err := client.SearchURI(index, "test", params)
+	_, result, err := client.SearchURI(index, "test", params)
 	if err != nil {
 		t.Errorf("SearchUri() returns an error: %s", err)
 	}
@@ -49,7 +49,7 @@ func TestIndex(t *testing.T) {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total)
 	}
 
-	resp, err = client.Delete(index, "test", "1", nil)
+	_, resp, err = client.Delete(index, "test", "1", nil)
 	if err != nil {
 		t.Errorf("Delete() returns error: %s", err)
 	}

--- a/outputs/elasticsearch/api_mock_test.go
+++ b/outputs/elasticsearch/api_mock_test.go
@@ -53,7 +53,7 @@ func TestOneHostSuccessResp(t *testing.T) {
 	params := map[string]string{
 		"refresh": "true",
 	}
-	resp, err := client.Index(index, "test", "1", params, body)
+	_, resp, err := client.Index(index, "test", "1", params, body)
 	if err != nil {
 		t.Errorf("Index() returns error: %s", err)
 	}
@@ -86,7 +86,7 @@ func TestOneHost500Resp(t *testing.T) {
 	params := map[string]string{
 		"refresh": "true",
 	}
-	_, err = client.Index(index, "test", "1", params, body)
+	_, _, err = client.Index(index, "test", "1", params, body)
 
 	if err == nil {
 		t.Errorf("Index() should return error.")
@@ -117,7 +117,7 @@ func TestOneHost503Resp(t *testing.T) {
 	params := map[string]string{
 		"refresh": "true",
 	}
-	_, err := client.Index(index, "test", "1", params, body)
+	_, _, err := client.Index(index, "test", "1", params, body)
 	if err == nil {
 		t.Errorf("Index() should return error.")
 	}

--- a/outputs/elasticsearch/bulkapi_integration_test.go
+++ b/outputs/elasticsearch/bulkapi_integration_test.go
@@ -48,7 +48,7 @@ func TestBulk(t *testing.T) {
 	params = map[string]string{
 		"q": "field1:value1",
 	}
-	result, err := client.SearchURI(index, "type1", params)
+	_, result, err := client.SearchURI(index, "type1", params)
 	if err != nil {
 		t.Errorf("SearchUri() returns an error: %s", err)
 	}
@@ -56,7 +56,7 @@ func TestBulk(t *testing.T) {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total)
 	}
 
-	_, err = client.Delete(index, "", "", nil)
+	_, _, err = client.Delete(index, "", "", nil)
 	if err != nil {
 		t.Errorf("Delete() returns error: %s", err)
 	}
@@ -157,7 +157,7 @@ func TestBulkMoreOperations(t *testing.T) {
 	params = map[string]string{
 		"q": "field1:value3",
 	}
-	result, err := client.SearchURI(index, "type1", params)
+	_, result, err := client.SearchURI(index, "type1", params)
 	if err != nil {
 		t.Errorf("SearchUri() returns an error: %s", err)
 	}
@@ -168,7 +168,7 @@ func TestBulkMoreOperations(t *testing.T) {
 	params = map[string]string{
 		"q": "field2:value2",
 	}
-	result, err = client.SearchURI(index, "type1", params)
+	_, result, err = client.SearchURI(index, "type1", params)
 	if err != nil {
 		t.Errorf("SearchUri() returns an error: %s", err)
 	}
@@ -176,7 +176,7 @@ func TestBulkMoreOperations(t *testing.T) {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total)
 	}
 
-	_, err = client.Delete(index, "", "", nil)
+	_, _, err = client.Delete(index, "", "", nil)
 	if err != nil {
 		t.Errorf("Delete() returns error: %s", err)
 	}

--- a/outputs/elasticsearch/client.go
+++ b/outputs/elasticsearch/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/elastic/libbeat/common"
 	"github.com/elastic/libbeat/logp"
+	"github.com/elastic/libbeat/outputs/mode"
 )
 
 type Client struct {
@@ -131,7 +132,7 @@ func (client *Client) PublishEvents(
 	if softFails > 0 {
 		events = removedDropped(events, dropInit)
 		events = removedDropped(events, dropFail)
-		return events, ErrTempBulkFailure
+		return events, mode.ErrTempBulkFailure
 	}
 
 	return nil, nil

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -27,7 +27,9 @@ var (
 const (
 	defaultMaxRetries = 3
 
-	elasticsearchDefaultTimeout = 30 * time.Second
+	defaultBulkSize = 50
+
+	elasticsearchDefaultTimeout = 90 * time.Second
 )
 
 func init() {
@@ -65,6 +67,12 @@ func (out *elasticsearchOutput) init(
 	tlsConfig, err := outputs.LoadTLSConfig(config.TLS)
 	if err != nil {
 		return err
+	}
+
+	// configure bulk size in config in case it is not set
+	if config.Bulk_size == nil {
+		bulkSize := defaultBulkSize
+		config.Bulk_size = &bulkSize
 	}
 
 	clients, err := mode.MakeClients(config, makeClientFactory(beat, tlsConfig, config))

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -22,8 +22,6 @@ var (
 )
 
 const (
-	defaultEsOpenTimeout = 3000 * time.Millisecond
-
 	defaultMaxRetries = 3
 
 	elasticsearchDefaultTimeout = 30 * time.Second

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -19,6 +19,11 @@ var (
 
 	// ErrJSONEncodeFailed indicates encoding failures
 	ErrJSONEncodeFailed = errors.New("json encode failed")
+
+	// ErrResponseRead indicates error parsing Elasticsearch response
+	ErrResponseRead = errors.New("bulk item status parse failed.")
+
+	ErrTempBulkFailure = errors.New("temporary bulk send failure")
 )
 
 const (

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -22,8 +22,6 @@ var (
 
 	// ErrResponseRead indicates error parsing Elasticsearch response
 	ErrResponseRead = errors.New("bulk item status parse failed.")
-
-	ErrTempBulkFailure = errors.New("temporary bulk send failure")
 )
 
 const (
@@ -96,7 +94,8 @@ func (out *elasticsearchOutput) init(
 	} else {
 		loadBalance := config.LoadBalance == nil || *config.LoadBalance
 		if loadBalance {
-			m, err = mode.NewLoadBalancerMode(clients, maxRetries, waitRetry, timeout)
+			m, err = mode.NewLoadBalancerMode(clients, maxRetries,
+				waitRetry, timeout, maxWaitRetry)
 		} else {
 			m, err = mode.NewFailOverConnectionMode(clients, maxRetries, waitRetry, timeout)
 		}

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -127,13 +127,13 @@ func TestOneEvent(t *testing.T) {
 	// before the refresh. We should find a better solution for this.
 	time.Sleep(200 * time.Millisecond)
 
-	_, err = client.Refresh(index)
+	_, _, err = client.Refresh(index)
 	if err != nil {
 		t.Errorf("Failed to refresh: %s", err)
 	}
 
 	defer func() {
-		_, err = client.Delete(index, "", "", nil)
+		_, _, err = client.Delete(index, "", "", nil)
 		if err != nil {
 			t.Errorf("Failed to delete index: %s", err)
 		}
@@ -142,7 +142,7 @@ func TestOneEvent(t *testing.T) {
 	params := map[string]string{
 		"q": "shipper:appserver1",
 	}
-	resp, err := client.SearchURI(index, "", params)
+	_, resp, err := client.SearchURI(index, "", params)
 
 	if err != nil {
 		t.Errorf("Failed to query elasticsearch for index(%s): %s", index, err)
@@ -216,13 +216,13 @@ func TestEvents(t *testing.T) {
 	}
 
 	defer func() {
-		_, err = output.randomClient().Delete(index, "", "", nil)
+		_, _, err = output.randomClient().Delete(index, "", "", nil)
 		if err != nil {
 			t.Errorf("Failed to delete index: %s", err)
 		}
 	}()
 
-	resp, err := output.randomClient().SearchURI(index, "", params)
+	_, resp, err := output.randomClient().SearchURI(index, "", params)
 
 	if err != nil {
 		t.Errorf("Failed to query elasticsearch: %s", err)
@@ -278,13 +278,13 @@ func testBulkWithParams(t *testing.T, output elasticsearchOutput) {
 	}
 
 	defer func() {
-		_, err := output.randomClient().Delete(index, "", "", nil)
+		_, _, err := output.randomClient().Delete(index, "", "", nil)
 		if err != nil {
 			t.Errorf("Failed to delete index: %s", err)
 		}
 	}()
 
-	resp, err := output.randomClient().SearchURI(index, "", params)
+	_, resp, err := output.randomClient().SearchURI(index, "", params)
 
 	if err != nil {
 		t.Errorf("Failed to query elasticsearch: %s", err)

--- a/outputs/elasticsearch/topology.go
+++ b/outputs/elasticsearch/topology.go
@@ -54,8 +54,8 @@ func (t *topology) EnableTTL() error {
 	// already exists. If index could not be created, next api call to index will
 	// fail anyway.
 	index := ".packetbeat-topology"
-	_, _ = client.CreateIndex(index, nil)
-	_, err := client.Index(index, "server-ip", "_mapping", nil, setting)
+	_, _, _ = client.CreateIndex(index, nil)
+	_, _, err := client.Index(index, "server-ip", "_mapping", nil, setting)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (t *topology) PublishIPs(name string, localAddrs []string) error {
 		"ttl":     fmt.Sprintf("%dms", t.TopologyExpire),
 		"refresh": "true",
 	}
-	_, err := client.Index(
+	_, _, err := client.Index(
 		".packetbeat-topology", //index
 		"server-ip",            //type
 		name,                   // id
@@ -126,14 +126,14 @@ func loadTopolgyMap(client *Client) (map[string]string, error) {
 	docType := "server-ip"
 
 	// get number of entries in index for search query to return all entries in one query
-	cntRes, err := client.CountSearchURI(index, docType, nil)
+	_, cntRes, err := client.CountSearchURI(index, docType, nil)
 	if err != nil {
 		logp.Err("Getting topology map fails with: %s", err)
 		return nil, err
 	}
 
 	params := map[string]string{"size": strconv.Itoa(cntRes.Count)}
-	res, err := client.SearchURI(index, docType, params)
+	_, res, err := client.SearchURI(index, docType, params)
 	if err != nil {
 		logp.Err("Getting topology map fails with: %s", err)
 		return nil, err

--- a/outputs/logstash/client_test.go
+++ b/outputs/logstash/client_test.go
@@ -82,7 +82,8 @@ func newClientTestDriver(client mode.ProtocolClient) *testClientDriver {
 				close(driver.ch)
 				return
 			case driverCmdPublish:
-				n, err := driver.client.PublishEvents(cmd.events)
+				events, err := driver.client.PublishEvents(cmd.events)
+				n := len(cmd.events) - len(events)
 				driver.returns = append(driver.returns, testClientReturn{n, err})
 			}
 		}

--- a/outputs/logstash/logstash.go
+++ b/outputs/logstash/logstash.go
@@ -42,11 +42,14 @@ type logstash struct {
 const (
 	logstashDefaultPort = 10200
 
-	logstashDefaultTimeout = 30 * time.Second
-	defaultSendRetries     = 3
+	logstashDefaultTimeout   = 30 * time.Second
+	logstasDefaultMaxTimeout = 90 * time.Second
+	defaultSendRetries       = 3
 )
 
 var waitRetry = time.Duration(1) * time.Second
+
+// NOTE: maxWaitRetry has no effect on mode, as logstash client currently does not return ErrTempBulkFailure
 var maxWaitRetry = time.Duration(60) * time.Second
 
 func (lj *logstash) init(
@@ -104,7 +107,8 @@ func (lj *logstash) init(
 	} else {
 		loadBalance := config.LoadBalance != nil && *config.LoadBalance
 		if loadBalance {
-			m, err = mode.NewLoadBalancerMode(clients, sendRetries, waitRetry, timeout)
+			m, err = mode.NewLoadBalancerMode(clients, sendRetries,
+				waitRetry, timeout, maxWaitRetry)
 		} else {
 			m, err = mode.NewFailOverConnectionMode(clients, sendRetries, waitRetry, timeout)
 		}

--- a/outputs/logstash/logstash_integration_test.go
+++ b/outputs/logstash/logstash_integration_test.go
@@ -89,9 +89,9 @@ func esConnect(t *testing.T, index string) *esConnection {
 	client := elasticsearch.NewClient(host, "", nil, "", "")
 
 	// try to drop old index if left over from failed test
-	_, _ = client.Delete(index, "", "", nil) // ignore error
+	_, _, _ = client.Delete(index, "", "", nil) // ignore error
 
-	_, err := client.CreateIndex(index, common.MapStr{
+	_, _, err := client.CreateIndex(index, common.MapStr{
 		"settings": common.MapStr{
 			"number_of_shards":   1,
 			"number_of_replicas": 0,
@@ -170,20 +170,20 @@ func newTestElasticsearchOutput(t *testing.T, test string) *testOutputer {
 }
 
 func (es *esConnection) Cleanup() {
-	_, err := es.Delete(es.index, "", "", nil)
+	_, _, err := es.Delete(es.index, "", "", nil)
 	if err != nil {
 		es.t.Errorf("Failed to delete index: %s", err)
 	}
 }
 
 func (es *esConnection) Read() ([]map[string]interface{}, error) {
-	_, err := es.Refresh(es.index)
+	_, _, err := es.Refresh(es.index)
 	if err != nil {
 		es.t.Errorf("Failed to refresh: %s", err)
 	}
 
 	params := map[string]string{}
-	resp, err := es.SearchURI(es.index, "", params)
+	_, resp, err := es.SearchURI(es.index, "", params)
 	if err != nil {
 		es.t.Errorf("Failed to query elasticsearch for index(%s): %s", es.index, err)
 		return nil, err
@@ -202,13 +202,13 @@ func (es *esConnection) RefreshIndex() {
 }
 
 func (es *esConnection) Count() (int, error) {
-	_, err := es.Refresh(es.index)
+	_, _, err := es.Refresh(es.index)
 	if err != nil {
 		es.t.Errorf("Failed to refresh: %s", err)
 	}
 
 	params := map[string]string{}
-	resp, err := es.CountSearchURI(es.index, "", params)
+	_, resp, err := es.CountSearchURI(es.index, "", params)
 	if err != nil {
 		es.t.Errorf("Failed to query elasticsearch for index(%s): %s", es.index, err)
 		return 0, err

--- a/outputs/logstash/logstash_integration_test.go
+++ b/outputs/logstash/logstash_integration_test.go
@@ -80,7 +80,7 @@ func getElasticsearchHost() string {
 }
 
 func esConnect(t *testing.T, index string) *esConnection {
-	ts := time.Now()
+	ts := time.Now().UTC()
 
 	host := getElasticsearchHost()
 	index = fmt.Sprintf("%s-%02d.%02d.%02d",
@@ -177,8 +177,6 @@ func (es *esConnection) Cleanup() {
 }
 
 func (es *esConnection) Read() ([]map[string]interface{}, error) {
-	fmt.Printf("try to read from index: %v\n", es.index)
-
 	_, err := es.Refresh(es.index)
 	if err != nil {
 		es.t.Errorf("Failed to refresh: %s", err)

--- a/outputs/mode/balance.go
+++ b/outputs/mode/balance.go
@@ -32,8 +32,9 @@ import (
 // Distributing events to workers is subject to timeout. If no worker is available to
 // pickup a message for sending, the message will be dropped internally.
 type LoadBalancerMode struct {
-	timeout   time.Duration // send/retry timeout. Every timeout is a failed send attempt
-	waitRetry time.Duration // duration to wait during re-connection attempts
+	timeout      time.Duration // Send/retry timeout. Every timeout is a failed send attempt
+	waitRetry    time.Duration // Duration to wait during re-connection attempts.
+	maxWaitRetry time.Duration // Maximum send/retry timeout in backoff case.
 
 	// maximum number of configured send attempts. If set to 0, publisher will
 	// block until event has been successfully published.
@@ -65,12 +66,13 @@ type eventsMessage struct {
 func NewLoadBalancerMode(
 	clients []ProtocolClient,
 	maxAttempts int,
-	waitRetry, timeout time.Duration,
+	waitRetry, timeout, maxWaitRetry time.Duration,
 ) (*LoadBalancerMode, error) {
 	m := &LoadBalancerMode{
-		timeout:     timeout,
-		waitRetry:   waitRetry,
-		maxAttempts: maxAttempts,
+		timeout:      timeout,
+		maxWaitRetry: maxWaitRetry,
+		waitRetry:    waitRetry,
+		maxAttempts:  maxAttempts,
 
 		work:    make(chan eventsMessage),
 		retries: make(chan eventsMessage, len(clients)*2),
@@ -174,21 +176,48 @@ func (m *LoadBalancerMode) onMessage(client ProtocolClient, msg eventsMessage) {
 	} else {
 		events := msg.events
 		total := len(events)
+		var backoffCount uint
 
 		for len(events) > 0 {
 			var err error
 
 			events, err = client.PublishEvents(events)
 			if err != nil {
-				// retry non-published subset of events in batch
-				msg.events = events
-
 				// reset attempt count if subset of messages has been processed
 				if len(events) < total {
 					msg.attemptsLeft = m.maxAttempts + 1
 				}
-				m.onFail(msg, err)
-				return
+
+				if err != ErrTempBulkFailure {
+					// retry non-published subset of events in batch
+					msg.events = events
+					m.onFail(msg, err)
+					return
+				}
+
+				msg.attemptsLeft--
+				if m.maxAttempts > 0 && msg.attemptsLeft <= 0 {
+					// no more attempts left => drop
+					outputs.SignalFailed(msg.signaler, err)
+					return
+				}
+
+				// wait before retry
+				backoff := time.Duration(int64(m.waitRetry) * (1 << backoffCount))
+				if backoff > m.maxWaitRetry {
+					backoff = m.maxWaitRetry
+				} else {
+					backoffCount++
+				}
+				select {
+				case <-m.done: // shutdown
+					outputs.SignalFailed(msg.signaler, err)
+					return
+				case <-time.After(backoff):
+				}
+
+				// reset total count for temporary failure loop
+				total = len(events)
 			}
 		}
 	}

--- a/outputs/mode/balance_test.go
+++ b/outputs/mode/balance_test.go
@@ -20,6 +20,7 @@ func TestLoadBalancerStartStop(t *testing.T) {
 		1,
 		100*time.Millisecond,
 		100*time.Millisecond,
+		1*time.Second,
 	)
 	testMode(t, mode, nil, nil, nil)
 }
@@ -37,6 +38,7 @@ func TestLoadBalancerFailSendWithoutActiveConnections(t *testing.T) {
 		2,
 		100*time.Millisecond,
 		100*time.Millisecond,
+		1*time.Second,
 	)
 	testMode(t, mode, multiEvent(2, testEvent), signals(false), nil)
 }
@@ -55,6 +57,7 @@ func TestLoadBalancerOKSend(t *testing.T) {
 		2,
 		100*time.Millisecond,
 		100*time.Millisecond,
+		1*time.Second,
 	)
 	testMode(t, mode, multiEvent(10, testEvent), signals(true), &collected)
 }
@@ -79,6 +82,26 @@ func TestLoadBalancerFlakyConnectionOkSend(t *testing.T) {
 		3,
 		100*time.Millisecond,
 		100*time.Millisecond,
+		1*time.Second,
+	)
+	testMode(t, mode, multiEvent(10, testEvent), signals(true), &collected)
+}
+
+func TestLoadBalancerTemporayFailure(t *testing.T) {
+	var collected [][]common.MapStr
+	mode, _ := NewLoadBalancerMode(
+		[]ProtocolClient{
+			&mockClient{
+				connected: true,
+				close:     closeOK,
+				connect:   connectOK,
+				publish:   publishFailWith(1, ErrTempBulkFailure, collectPublish(&collected)),
+			},
+		},
+		3,
+		100*time.Millisecond,
+		100*time.Millisecond,
+		1*time.Second,
 	)
 	testMode(t, mode, multiEvent(10, testEvent), signals(true), &collected)
 }

--- a/outputs/mode/mode.go
+++ b/outputs/mode/mode.go
@@ -60,6 +60,11 @@ type ProtocolClient interface {
 	PublishEvent(event common.MapStr) error
 }
 
+var (
+	// ErrTempBulkFailure indicates PublishEvents fail temporary to retry.
+	ErrTempBulkFailure = errors.New("temporary bulk send failure")
+)
+
 // MakeClients will create a list from of ProtocolClient instances from
 // outputer configuration host list and client factory function.
 func MakeClients(

--- a/outputs/mode/mode.go
+++ b/outputs/mode/mode.go
@@ -52,9 +52,8 @@ type ProtocolClient interface {
 	// must be set. If connection has been lost, IsConnected must return false
 	// in future calls.
 	// PublishEvents is free to publish only a subset of given events, even in
-	// error case. On return n indicates the number of events guaranteed to be
-	// published.
-	PublishEvents(events []common.MapStr) (n int, err error)
+	// error case. On return nextEvents contains all events not yet published.
+	PublishEvents(events []common.MapStr) (nextEvents []common.MapStr, err error)
 
 	// PublishEvent sends one event to the clients sink. On failure and error is
 	// returned.

--- a/outputs/mode/mode_test.go
+++ b/outputs/mode/mode_test.go
@@ -95,19 +95,27 @@ func publishTimeoutEvery(
 	}
 }
 
-func publishFailStart(
+func publishFailWith(
 	n int,
-	pub func(events []common.MapStr) ([]common.MapStr, error),
-) func(events []common.MapStr) ([]common.MapStr, error) {
+	err error,
+	pub func([]common.MapStr) ([]common.MapStr, error),
+) func([]common.MapStr) ([]common.MapStr, error) {
 	count := 0
 	return func(events []common.MapStr) ([]common.MapStr, error) {
 		if count < n {
 			count++
-			return events, errNetTimeout{}
+			return events, err
 		}
 		count = 0
 		return pub(events)
 	}
+}
+
+func publishFailStart(
+	n int,
+	pub func(events []common.MapStr) ([]common.MapStr, error),
+) func(events []common.MapStr) ([]common.MapStr, error) {
+	return publishFailWith(n, errNetTimeout{}, pub)
 }
 
 func closeOK() error {

--- a/outputs/mode/mode_test.go
+++ b/outputs/mode/mode_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type mockClient struct {
-	publish   func([]common.MapStr) (int, error)
+	publish   func([]common.MapStr) ([]common.MapStr, error)
 	close     func() error
 	connected bool
 	connect   func(time.Duration) error
@@ -30,7 +30,7 @@ func (c *mockClient) IsConnected() bool {
 	return c.connected
 }
 
-func (c *mockClient) PublishEvents(events []common.MapStr) (int, error) {
+func (c *mockClient) PublishEvents(events []common.MapStr) ([]common.MapStr, error) {
 	return c.publish(events)
 }
 
@@ -63,14 +63,14 @@ func alwaysFailConnect(err error) func(time.Duration) error {
 
 func collectPublish(
 	collected *[][]common.MapStr,
-) func(events []common.MapStr) (int, error) {
+) func(events []common.MapStr) ([]common.MapStr, error) {
 	mutex := sync.Mutex{}
-	return func(events []common.MapStr) (int, error) {
+	return func(events []common.MapStr) ([]common.MapStr, error) {
 		mutex.Lock()
 		defer mutex.Unlock()
 
 		*collected = append(*collected, events)
-		return len(events), nil
+		return nil, nil
 	}
 }
 
@@ -82,28 +82,28 @@ func (e errNetTimeout) Temporary() bool { return false }
 
 func publishTimeoutEvery(
 	n int,
-	pub func(events []common.MapStr) (int, error),
-) func(events []common.MapStr) (int, error) {
+	pub func(events []common.MapStr) ([]common.MapStr, error),
+) func(events []common.MapStr) ([]common.MapStr, error) {
 	count := 0
-	return func(events []common.MapStr) (int, error) {
+	return func(events []common.MapStr) ([]common.MapStr, error) {
 		if count < n {
 			count++
 			return pub(events)
 		}
 		count = 0
-		return 0, errNetTimeout{}
+		return events, errNetTimeout{}
 	}
 }
 
 func publishFailStart(
 	n int,
-	pub func(events []common.MapStr) (int, error),
-) func(events []common.MapStr) (int, error) {
+	pub func(events []common.MapStr) ([]common.MapStr, error),
+) func(events []common.MapStr) ([]common.MapStr, error) {
 	count := 0
-	return func(events []common.MapStr) (int, error) {
+	return func(events []common.MapStr) ([]common.MapStr, error) {
 		if count < n {
 			count++
-			return 0, errNetTimeout{}
+			return events, errNetTimeout{}
 		}
 		count = 0
 		return pub(events)

--- a/outputs/mode/single.go
+++ b/outputs/mode/single.go
@@ -65,7 +65,6 @@ func (s *SingleConnectionMode) PublishEvents(
 	signaler outputs.Signaler,
 	events []common.MapStr,
 ) error {
-	published := 0
 	fails := 0
 	var backoffCount uint
 	var err error
@@ -76,18 +75,18 @@ func (s *SingleConnectionMode) PublishEvents(
 			goto sendFail
 		}
 
-		for published < len(events) {
-			n, err := s.conn.PublishEvents(events[published:])
+		for len(events) > 0 {
+			var err error
+			events, err = s.conn.PublishEvents(events)
 			if err != nil {
 				logp.Info("Error publishing events (retrying): %s", err)
 				break
 			}
 
 			fails = 0
-			published += n
 		}
 
-		if published == len(events) {
+		if len(events) == 0 {
 			outputs.SignalCompleted(signaler)
 			return nil
 		}

--- a/publisher/async.go
+++ b/publisher/async.go
@@ -47,8 +47,8 @@ func (p *asyncPublisher) onMessage(m message) {
 	// be implemented in the furute.
 	// If m.signal is nil, NewSplitSignaler will return nil -> signaler will
 	// only set if client did send one
-	if m.signal != nil && len(p.outputs) > 1 {
-		m.signal = outputs.NewSplitSignaler(m.signal, len(p.outputs))
+	if m.context.signal != nil && len(p.outputs) > 1 {
+		m.context.signal = outputs.NewSplitSignaler(m.context.signal, len(p.outputs))
 	}
 	for _, o := range p.outputs {
 		o.send(m)
@@ -59,12 +59,12 @@ func (p *asyncPublisher) client() eventPublisher {
 	return asyncClient(p.send)
 }
 
-func (c asyncClient) PublishEvent(event common.MapStr) bool {
-	return c.send(message{event: event})
+func (c asyncClient) PublishEvent(ctx *context, event common.MapStr) bool {
+	return c.send(message{context: *ctx, event: event})
 }
 
-func (c asyncClient) PublishEvents(events []common.MapStr) bool {
-	return c.send(message{events: events})
+func (c asyncClient) PublishEvents(ctx *context, events []common.MapStr) bool {
+	return c.send(message{context: *ctx, events: events})
 }
 
 func (c asyncClient) send(m message) bool {

--- a/publisher/async_test.go
+++ b/publisher/async_test.go
@@ -13,7 +13,7 @@ func TestAsyncPublishEvent(t *testing.T) {
 	event := testEvent()
 
 	// Execute. Async PublishEvent always immediately returns true.
-	assert.True(t, testPub.pub.asyncPublisher.client().PublishEvent(event))
+	assert.True(t, testPub.asyncPublishEvent(event))
 
 	// Validate
 	msgs, err := testPub.outputMsgHandler.waitForMessages(1)
@@ -29,7 +29,7 @@ func TestAsyncPublishEvents(t *testing.T) {
 	events := []common.MapStr{testEvent(), testEvent()}
 
 	// Execute. Async PublishEvent always immediately returns true.
-	assert.True(t, testPub.pub.asyncPublisher.client().PublishEvents(events))
+	assert.True(t, testPub.asyncPublishEvents(events))
 
 	// Validate
 	msgs, err := testPub.outputMsgHandler.waitForMessages(1)
@@ -46,7 +46,7 @@ func TestBulkAsyncPublishEvent(t *testing.T) {
 	event := testEvent()
 
 	// Execute. Async PublishEvent always immediately returns true.
-	assert.True(t, testPub.pub.asyncPublisher.client().PublishEvent(event))
+	assert.True(t, testPub.asyncPublishEvent(event))
 
 	// validate
 	msgs, err := testPub.outputMsgHandler.waitForMessages(1)
@@ -64,7 +64,7 @@ func TestBulkAsyncPublishEvents(t *testing.T) {
 	events := []common.MapStr{testEvent(), testEvent()}
 
 	// Async PublishEvent always immediately returns true.
-	assert.True(t, testPub.pub.asyncPublisher.client().PublishEvents(events))
+	assert.True(t, testPub.asyncPublishEvents(events))
 
 	msgs, err := testPub.outputMsgHandler.waitForMessages(1)
 	if err != nil {

--- a/publisher/bulk.go
+++ b/publisher/bulk.go
@@ -52,9 +52,9 @@ func (b *bulkWorker) run() {
 			return
 		case m := <-b.queue:
 			if m.event != nil { // single event
-				b.onEvent(m.signal, m.event)
+				b.onEvent(m.context.signal, m.event)
 			} else { // batch of events
-				b.onEvents(m.signal, m.events)
+				b.onEvents(m.context.signal, m.events)
 			}
 
 			// buffer full?
@@ -108,8 +108,11 @@ func (b *bulkWorker) onEvents(signal outputs.Signaler, events []common.MapStr) {
 }
 
 func (b *bulkWorker) publish() {
+	// TODO: remember/merge and forward context options to output worker
 	b.output.send(message{
-		signal: outputs.NewCompositeSignaler(b.pending...),
+		context: context{
+			signal: outputs.NewCompositeSignaler(b.pending...),
+		},
 		events: b.events,
 	})
 

--- a/publisher/bulk_test.go
+++ b/publisher/bulk_test.go
@@ -26,7 +26,7 @@ func TestBulkWorkerSendSingle(t *testing.T) {
 	bw := newBulkWorker(ws, queueSize, mh, flushInterval, maxBatchSize)
 
 	s := newTestSignaler()
-	m := message{event: testEvent(), signal: s}
+	m := testMessage(s, testEvent())
 	bw.send(m)
 	msgs, err := mh.waitForMessages(1)
 	if err != nil {
@@ -53,7 +53,7 @@ func TestBulkWorkerSendBatch(t *testing.T) {
 		events[i] = testEvent()
 	}
 	s := newTestSignaler()
-	m := message{events: events, signal: s}
+	m := testBulkMessage(s, events)
 	bw.send(m)
 
 	// Validate
@@ -84,7 +84,7 @@ func TestBulkWorkerSendBatchGreaterThanMaxBatchSize(t *testing.T) {
 		events[i] = testEvent()
 	}
 	s := newTestSignaler()
-	m := message{events: events, signal: s}
+	m := testBulkMessage(s, events)
 	bw.send(m)
 
 	// Read first message and verify no Completed or Failed signal has

--- a/publisher/client_test.go
+++ b/publisher/client_test.go
@@ -18,8 +18,8 @@ func TestGetClient(t *testing.T) {
 		},
 	}
 	asyncClient := c.publisher.asyncPublisher.client()
-	confirmClient := c.publisher.syncPublisher.client(true)
-	syncClient := c.publisher.syncPublisher.client(false)
+	confirmClient := c.publisher.syncPublisher.client()
+	syncClient := c.publisher.syncPublisher.client()
 
 	var testCases = []struct {
 		in  []ClientOption
@@ -34,7 +34,8 @@ func TestGetClient(t *testing.T) {
 
 	for _, test := range testCases {
 		expected := reflect.ValueOf(test.out)
-		actual := reflect.ValueOf(c.getClient(test.in))
+		_, client := c.getClient(test.in)
+		actual := reflect.ValueOf(client)
 		assert.Equal(t, expected.Pointer(), actual.Pointer())
 	}
 }

--- a/publisher/output.go
+++ b/publisher/output.go
@@ -10,8 +10,9 @@ import (
 
 type outputWorker struct {
 	messageWorker
-	out    outputs.BulkOutputer
-	config outputs.MothershipConfig
+	out         outputs.BulkOutputer
+	config      outputs.MothershipConfig
+	maxBulkSize int
 }
 
 func newOutputWorker(
@@ -20,7 +21,16 @@ func newOutputWorker(
 	ws *workerSignal,
 	hwm int,
 ) *outputWorker {
-	o := &outputWorker{out: outputs.CastBulkOutputer(out), config: config}
+	maxBulkSize := defaultBulkSize
+	if config.Bulk_size != nil {
+		maxBulkSize = *config.Bulk_size
+	}
+
+	o := &outputWorker{
+		out:         outputs.CastBulkOutputer(out),
+		config:      config,
+		maxBulkSize: maxBulkSize,
+	}
 	o.messageWorker.init(ws, hwm, o)
 	return o
 }
@@ -30,22 +40,45 @@ func (o *outputWorker) onStop() {}
 func (o *outputWorker) onMessage(m message) {
 
 	if m.event != nil {
-		debug("output worker: publish single event")
-		ts := time.Time(m.event["@timestamp"].(common.Time)).UTC()
-		_ = o.out.PublishEvent(m.signal, ts, m.event)
+		o.onEvent(m.signal, m.event)
 	} else {
-		if len(m.events) == 0 {
-			debug("output worker: no events to publish")
-			outputs.SignalCompleted(m.signal)
-			return
-		}
+		o.onBulk(m.signal, m.events)
+	}
+}
 
-		debug("output worker: publish %v events", len(m.events))
-		ts := time.Time(m.events[0]["@timestamp"].(common.Time)).UTC()
-		err := o.out.BulkPublish(m.signal, ts, m.events)
+func (o *outputWorker) onEvent(s outputs.Signaler, event common.MapStr) {
+	debug("output worker: publish single event")
+	ts := time.Time(event["@timestamp"].(common.Time)).UTC()
+	_ = o.out.PublishEvent(s, ts, event)
+}
 
-		if err != nil {
-			logp.Info("Error bulk publishing events: %s", err)
-		}
+func (o *outputWorker) onBulk(signal outputs.Signaler, events []common.MapStr) {
+	if len(events) == 0 {
+		debug("output worker: no events to publish")
+		outputs.SignalCompleted(signal)
+		return
+	}
+
+	if o.maxBulkSize < 0 || len(events) <= o.maxBulkSize {
+		o.sendBulk(signal, events)
+		return
+	}
+
+	// start splitting bulk request
+	splits := (len(events) + (o.maxBulkSize - 1)) / o.maxBulkSize
+	signal = outputs.NewSplitSignaler(signal, splits)
+	for len(events) > 0 {
+		o.sendBulk(signal, events[:o.maxBulkSize])
+		events = events[o.maxBulkSize:]
+	}
+}
+
+func (o *outputWorker) sendBulk(signal outputs.Signaler, events []common.MapStr) {
+	debug("output worker: publish %v events", len(events))
+	ts := time.Time(events[0]["@timestamp"].(common.Time)).UTC()
+
+	err := o.out.BulkPublish(signal, ts, events)
+	if err != nil {
+		logp.Info("Error bulk publishing events: %s", err)
 	}
 }

--- a/publisher/output.go
+++ b/publisher/output.go
@@ -40,45 +40,79 @@ func (o *outputWorker) onStop() {}
 func (o *outputWorker) onMessage(m message) {
 
 	if m.event != nil {
-		o.onEvent(m.signal, m.event)
+		o.onEvent(&m.context, m.event)
 	} else {
-		o.onBulk(m.signal, m.events)
+		o.onBulk(&m.context, m.events)
 	}
 }
 
-func (o *outputWorker) onEvent(s outputs.Signaler, event common.MapStr) {
+func (o *outputWorker) onEvent(ctx *context, event common.MapStr) {
 	debug("output worker: publish single event")
 	ts := time.Time(event["@timestamp"].(common.Time)).UTC()
-	_ = o.out.PublishEvent(s, ts, event)
-}
 
-func (o *outputWorker) onBulk(signal outputs.Signaler, events []common.MapStr) {
-	if len(events) == 0 {
-		debug("output worker: no events to publish")
-		outputs.SignalCompleted(signal)
+	if !ctx.sync {
+		_ = o.out.PublishEvent(ctx.signal, ts, event)
 		return
 	}
 
+	signal := outputs.NewSyncSignal()
+	for {
+		o.out.PublishEvent(signal, ts, event)
+		if signal.Wait() {
+			outputs.SignalCompleted(ctx.signal)
+			break
+		}
+	}
+}
+
+func (o *outputWorker) onBulk(ctx *context, events []common.MapStr) {
+	if len(events) == 0 {
+		debug("output worker: no events to publish")
+		outputs.SignalCompleted(ctx.signal)
+		return
+	}
+
+	var sync *outputs.SyncSignal
+	if ctx.sync {
+		sync = outputs.NewSyncSignal()
+	}
+
 	if o.maxBulkSize < 0 || len(events) <= o.maxBulkSize {
-		o.sendBulk(signal, events)
+		o.sendBulk(sync, ctx, events)
 		return
 	}
 
 	// start splitting bulk request
 	splits := (len(events) + (o.maxBulkSize - 1)) / o.maxBulkSize
-	signal = outputs.NewSplitSignaler(signal, splits)
+	ctx.signal = outputs.NewSplitSignaler(ctx.signal, splits)
 	for len(events) > 0 {
-		o.sendBulk(signal, events[:o.maxBulkSize])
-		events = events[o.maxBulkSize:]
+		sz := o.maxBulkSize
+		if sz > len(events) {
+			sz = len(events)
+		}
+		o.sendBulk(sync, ctx, events[:sz])
+		events = events[sz:]
 	}
 }
 
-func (o *outputWorker) sendBulk(signal outputs.Signaler, events []common.MapStr) {
+func (o *outputWorker) sendBulk(
+	sync *outputs.SyncSignal,
+	ctx *context,
+	events []common.MapStr,
+) {
 	debug("output worker: publish %v events", len(events))
 	ts := time.Time(events[0]["@timestamp"].(common.Time)).UTC()
 
-	err := o.out.BulkPublish(signal, ts, events)
-	if err != nil {
-		logp.Info("Error bulk publishing events: %s", err)
+	if sync == nil {
+		err := o.out.BulkPublish(ctx.signal, ts, events)
+		if err != nil {
+			logp.Info("Error bulk publishing events: %s", err)
+		}
+		return
 	}
+
+	for done := false; !done; done = sync.Wait() {
+		o.out.BulkPublish(sync, ts, events)
+	}
+	outputs.SignalCompleted(ctx.signal)
 }

--- a/publisher/output_test.go
+++ b/publisher/output_test.go
@@ -37,13 +37,13 @@ func TestOutputWorker(t *testing.T) {
 	ow.onStop() // Noop
 
 	var testCases = []message{
-		message{signal: newTestSignaler()},
-		message{signal: newTestSignaler(), event: testEvent()},
-		message{signal: newTestSignaler(), events: []common.MapStr{testEvent()}},
+		testMessage(newTestSignaler(), nil),
+		testMessage(newTestSignaler(), testEvent()),
+		testBulkMessage(newTestSignaler(), []common.MapStr{testEvent()}),
 	}
 
 	for _, m := range testCases {
-		sig := m.signal.(*testSignaler)
+		sig := m.context.signal.(*testSignaler)
 		ow.onMessage(m)
 		assert.True(t, sig.wait())
 

--- a/publisher/preprocess.go
+++ b/publisher/preprocess.go
@@ -66,7 +66,7 @@ func (p *preprocessor) onMessage(m message) {
 	// return if no event is left
 	if len(ignore) == len(events) {
 		debug("no event left, complete send")
-		outputs.SignalCompleted(m.signal)
+		outputs.SignalCompleted(m.context.signal)
 		return
 	}
 
@@ -84,15 +84,15 @@ func (p *preprocessor) onMessage(m message) {
 
 	if publisher.disabled {
 		debug("publisher disabled")
-		outputs.SignalCompleted(m.signal)
+		outputs.SignalCompleted(m.context.signal)
 		return
 	}
 
 	debug("preprocessor forward")
 	if single {
-		p.handler.onMessage(message{signal: m.signal, event: events[0]})
+		p.handler.onMessage(message{context: m.context, event: events[0]})
 	} else {
-		p.handler.onMessage(message{signal: m.signal, events: events})
+		p.handler.onMessage(message{context: m.context, events: events})
 	}
 }
 

--- a/publisher/publish.go
+++ b/publisher/publish.go
@@ -27,8 +27,18 @@ var debug = logp.MakeDebug("publish")
 
 // EventPublisher provides the interface for beats to publish events.
 type eventPublisher interface {
-	PublishEvent(event common.MapStr) bool
-	PublishEvents(events []common.MapStr) bool
+	PublishEvent(ctx *context, event common.MapStr) bool
+	PublishEvents(ctx *context, events []common.MapStr) bool
+}
+
+type context struct {
+	publishOptions
+	signal outputs.Signaler
+}
+
+type publishOptions struct {
+	confirm bool
+	sync    bool
 }
 
 type TransactionalEventPublisher interface {

--- a/publisher/sync_test.go
+++ b/publisher/sync_test.go
@@ -11,7 +11,7 @@ func TestSyncPublishEventSuccess(t *testing.T) {
 	testPub := newTestPublisherNoBulk(CompletedResponse)
 	event := testEvent()
 
-	assert.True(t, testPub.pub.syncPublisher.client(true).PublishEvent(event))
+	assert.True(t, testPub.syncPublishEvent(event))
 
 	msgs, err := testPub.outputMsgHandler.waitForMessages(1)
 	if err != nil {
@@ -24,7 +24,7 @@ func TestSyncPublishEventsSuccess(t *testing.T) {
 	testPub := newTestPublisherNoBulk(CompletedResponse)
 	events := []common.MapStr{testEvent(), testEvent()}
 
-	assert.True(t, testPub.pub.syncPublisher.client(true).PublishEvents(events))
+	assert.True(t, testPub.syncPublishEvents(events))
 
 	msgs, err := testPub.outputMsgHandler.waitForMessages(1)
 	if err != nil {
@@ -38,7 +38,7 @@ func TestSyncPublishEventFailed(t *testing.T) {
 	testPub := newTestPublisherNoBulk(FailedResponse)
 	event := testEvent()
 
-	assert.False(t, testPub.pub.syncPublisher.client(true).PublishEvent(event))
+	assert.False(t, testPub.syncPublishEvent(event))
 
 	msgs, err := testPub.outputMsgHandler.waitForMessages(1)
 	if err != nil {
@@ -51,7 +51,7 @@ func TestSyncPublishEventsFailed(t *testing.T) {
 	testPub := newTestPublisherNoBulk(FailedResponse)
 	events := []common.MapStr{testEvent(), testEvent()}
 
-	assert.False(t, testPub.pub.syncPublisher.client(true).PublishEvents(events))
+	assert.False(t, testPub.syncPublishEvents(events))
 
 	msgs, err := testPub.outputMsgHandler.waitForMessages(1)
 	if err != nil {
@@ -67,5 +67,5 @@ func TestSyncPublisherDisabled(t *testing.T) {
 	testPub.pub.disabled = true
 	event := testEvent()
 
-	assert.True(t, testPub.pub.syncPublisher.client(true).PublishEvent(event))
+	assert.True(t, testPub.syncPublishEvent(event))
 }

--- a/publisher/worker.go
+++ b/publisher/worker.go
@@ -18,9 +18,9 @@ type messageWorker struct {
 }
 
 type message struct {
-	signal outputs.Signaler
-	event  common.MapStr
-	events []common.MapStr
+	context context
+	event   common.MapStr
+	events  []common.MapStr
 }
 
 type workerSignal struct {
@@ -87,6 +87,6 @@ func (ws *workerSignal) Init() {
 func stopQueue(qu chan message) {
 	close(qu)
 	for msg := range qu { // clear queue and send fail signal
-		outputs.SignalFailed(msg.signal, nil)
+		outputs.SignalFailed(msg.context.signal, nil)
 	}
 }

--- a/publisher/worker_test.go
+++ b/publisher/worker_test.go
@@ -16,12 +16,12 @@ func TestMessageWorkerSend(t *testing.T) {
 
 	// Send an event.
 	s1 := newTestSignaler()
-	m1 := message{signal: s1}
+	m1 := message{context: context{signal: s1}}
 	mw.send(m1)
 
 	// Send another event.
 	s2 := newTestSignaler()
-	m2 := message{signal: s2}
+	m2 := message{context: context{signal: s2}}
 	mw.send(m2)
 
 	// Verify that the messageWorker pushed to two messages to the
@@ -46,10 +46,10 @@ func TestMessageWorkerSend(t *testing.T) {
 // Test that stopQueue invokes the Failed callback on all events in the queue.
 func TestMessageWorkerStopQueue(t *testing.T) {
 	s1 := newTestSignaler()
-	m1 := message{signal: s1}
+	m1 := message{context: context{signal: s1}}
 
 	s2 := newTestSignaler()
-	m2 := message{signal: s2}
+	m2 := message{context: context{signal: s2}}
 
 	qu := make(chan message, 2)
 	qu <- m1


### PR DESCRIPTION
Iterate bulk request response items and check status code.
On first status code >= 300 an error is returned with number
of successful send (and so far checked) items.

On failure the send modes will retry sending all events beginning
with first failed event. If bulk output mode is used, the remaining items
are forwarded to another worker for sending.

Closes #192 