### PR TITLE
Fix #227: Improve error message in run windows service

### DIFF
--- a/outputs/logstash/logstash.go
+++ b/outputs/logstash/logstash.go
@@ -6,7 +6,6 @@ package logstash
 import (
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/elastic/libbeat/common"
@@ -191,5 +190,4 @@ func (lj *logstash) addMeta(event common.MapStr) {
 		"beat": lj.index,
 		"type": event["type"].(string),
 	}
-	fmt.Printf("meta data: %v\n", event["@metadata"])
 }

--- a/service/service_windows.go
+++ b/service/service_windows.go
@@ -42,7 +42,8 @@ loop:
 func ProcessWindowsControlEvents(stopCallback func()) {
 	err := svc.Run(os.Args[0], &beatService{})
 	if err != nil {
-		logp.Err("Error: %v", err)
+		logp.Info("Error executing service: %v", err)
+		logp.Info("If Windows service is run in foreground, the above error is expected and can be ignored.")
 	} else {
 		stopCallback()
 	}


### PR DESCRIPTION
Improve the error message to better explain what happens
Change the log level of the message to Info as it is not critical