### PR TITLE
If the session is interactive, don't print service errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file based on the
 - Limit number of workers for Elasticsearch output to 1 per configured host. packetbeat#226
 - Respect '*' debug selector in IsDebug. #226 (elastic/packetbeat#339)
 - Limit number of workers for Elasticsearch output. elastic/packetbeat#226
+- On Windows, remove service related error message when running in the console. #242
 
 ### Added
 - Add Console output plugin. #218


### PR DESCRIPTION
We can detect if we run in a service or not and call
different Run functions for each. Fixes #227.