### PR TITLE
single mode timeout config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file based on the
 - Respect '*' debug selector in IsDebug. #226 (elastic/packetbeat#339)
 - Limit number of workers for Elasticsearch output. elastic/packetbeat#226
 - On Windows, remove service related error message when running in the console. #242
+- Fix waitRetry no configured in single output mode configuration. elastic/filebeat#144
 
 ### Added
 - Add Console output plugin. #218

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -82,12 +82,14 @@ func (out *elasticsearchOutput) init(
 	}
 
 	var waitRetry = time.Duration(1) * time.Second
+	var maxWaitRetry = time.Duration(60) * time.Second
 
 	var m mode.ConnectionMode
 	out.clients = clients
 	if len(clients) == 1 {
 		client := clients[0]
-		m, err = mode.NewSingleConnectionMode(client, maxRetries, waitRetry, timeout)
+		m, err = mode.NewSingleConnectionMode(client, maxRetries,
+			waitRetry, timeout, maxWaitRetry)
 	} else {
 		loadBalance := config.LoadBalance == nil || *config.LoadBalance
 		if loadBalance {

--- a/outputs/logstash/logstash.go
+++ b/outputs/logstash/logstash.go
@@ -47,6 +47,7 @@ const (
 )
 
 var waitRetry = time.Duration(1) * time.Second
+var maxWaitRetry = time.Duration(60) * time.Second
 
 func (lj *logstash) init(
 	beat string,
@@ -99,7 +100,7 @@ func (lj *logstash) init(
 	var m mode.ConnectionMode
 	if len(clients) == 1 {
 		m, err = mode.NewSingleConnectionMode(clients[0],
-			sendRetries, waitRetry, timeout)
+			sendRetries, waitRetry, timeout, maxWaitRetry)
 	} else {
 		loadBalance := config.LoadBalance != nil && *config.LoadBalance
 		if loadBalance {

--- a/outputs/mode/single_test.go
+++ b/outputs/mode/single_test.go
@@ -20,6 +20,7 @@ func testSingleSendOneEvent(t *testing.T, events []eventInfo) {
 		3,
 		0,
 		100*time.Millisecond,
+		1*time.Second,
 	)
 	testMode(t, mode, events, signals(true), &collected)
 }
@@ -45,6 +46,7 @@ func testSingleConnectFailConnectAndSend(t *testing.T, events []eventInfo) {
 		3,
 		0,
 		100*time.Millisecond,
+		1*time.Second,
 	)
 	testMode(t, mode, events, signals(true), &collected)
 }
@@ -70,6 +72,7 @@ func testSingleConnectionFail(t *testing.T, events []eventInfo) {
 		3,
 		0,
 		100*time.Millisecond,
+		1*time.Second,
 	)
 	testMode(t, mode, events, signals(false), &collected)
 }
@@ -94,6 +97,7 @@ func testSingleSendFlaky(t *testing.T, events []eventInfo) {
 		3,
 		0,
 		100*time.Millisecond,
+		1*time.Second,
 	)
 	testMode(t, mode, singleEvent(testEvent), signals(true), &collected)
 }


### PR DESCRIPTION
- fix timeout configuration not applied to single mode
- add additional backoff mode to single mode on failure

Resolve elastic/filebeat#144