### PR TITLE
Rename bulk_size to bulk_max_size

### DIFF
--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -70,9 +70,9 @@ func (out *elasticsearchOutput) init(
 	}
 
 	// configure bulk size in config in case it is not set
-	if config.Bulk_size == nil {
+	if config.BulkMaxSize == nil {
 		bulkSize := defaultBulkSize
-		config.Bulk_size = &bulkSize
+		config.BulkMaxSize = &bulkSize
 	}
 
 	clients, err := mode.MakeClients(config, makeClientFactory(beat, tlsConfig, config))

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -33,7 +33,7 @@ func createElasticsearchConnection(flushInterval int, bulkSize int) elasticsearc
 		Index:          index,
 		Protocol:       "http",
 		Flush_interval: &flushInterval,
-		Bulk_size:      &bulkSize,
+		BulkMaxSize:    &bulkSize,
 	}, 10)
 
 	return output

--- a/outputs/fileout/file.go
+++ b/outputs/fileout/file.go
@@ -42,7 +42,7 @@ func (out *fileOutput) init(beat string, config *outputs.MothershipConfig, topol
 	// disable bulk support
 	configDisableInt := -1
 	config.Flush_interval = &configDisableInt
-	config.Bulk_size = &configDisableInt
+	config.BulkMaxSize = &configDisableInt
 
 	rotateeverybytes := uint64(config.Rotate_every_kb) * 1024
 	if rotateeverybytes == 0 {

--- a/outputs/logstash/logstash_integration_test.go
+++ b/outputs/logstash/logstash_integration_test.go
@@ -155,7 +155,7 @@ func newTestElasticsearchOutput(t *testing.T, test string) *testOutputer {
 		Hosts:          []string{getElasticsearchHost()},
 		Index:          index,
 		Flush_interval: &flushInterval,
-		Bulk_size:      &bulkSize,
+		BulkMaxSize:    &bulkSize,
 	}
 
 	output, err := plugin.NewOutput("test", &config, 10)

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -28,7 +28,7 @@ type MothershipConfig struct {
 	Number_of_files    int
 	DataType           string
 	Flush_interval     *int
-	Bulk_size          *int
+	BulkMaxSize        *int `yaml:"bulk_max_size"`
 	Max_retries        *int
 	Pretty             *bool
 	TLS                *TLSConfig

--- a/publisher/async.go
+++ b/publisher/async.go
@@ -82,8 +82,8 @@ func asyncOutputer(ws *workerSignal, worker *outputWorker) worker {
 	}
 
 	maxBulkSize := defaultBulkSize
-	if config.Bulk_size != nil {
-		maxBulkSize = *config.Bulk_size
+	if config.BulkMaxSize != nil {
+		maxBulkSize = *config.BulkMaxSize
 	}
 
 	// batching disabled

--- a/publisher/common_test.go
+++ b/publisher/common_test.go
@@ -137,7 +137,7 @@ func newTestPublisher(bulkSize int, response OutputResponse) *testPublisher {
 	}
 
 	ow := &outputWorker{}
-	ow.config.Bulk_size = &bulkSize
+	ow.config.BulkMaxSize = &bulkSize
 	ow.handler = mh
 	ws := workerSignal{}
 	ow.messageWorker.init(&ws, 1000, mh)

--- a/publisher/output.go
+++ b/publisher/output.go
@@ -22,8 +22,8 @@ func newOutputWorker(
 	hwm int,
 ) *outputWorker {
 	maxBulkSize := defaultBulkSize
-	if config.Bulk_size != nil {
-		maxBulkSize = *config.Bulk_size
+	if config.BulkMaxSize != nil {
+		maxBulkSize = *config.BulkMaxSize
 	}
 
 	o := &outputWorker{

--- a/publisher/publish.go
+++ b/publisher/publish.go
@@ -193,7 +193,7 @@ func (publisher *PublisherType) Init(
 			output := plugin.Output
 			config := plugin.Config
 
-			debug("create output worker: %p, %p", config.Flush_interval, config.Bulk_size)
+			debug("create output worker: %p, %p", config.Flush_interval, config.BulkMaxSize)
 
 			outputers = append(outputers,
 				newOutputWorker(config, output, &publisher.wsOutput, 1000))


### PR DESCRIPTION
Rename bulk_size config variable to bulk_max_size to match existing documentation and configuration files.

Closes #251