### PR TITLE
Respect max_retries=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file based on the
 - Respect max bulk size if bulk publisher (collector) is disabled or sync flag is set.
 - Always evaluate status code from Elasticsearch responses when indexing events. #192
 - Use bulk_max_size configuration option instead of bulk_size. #256
+- Fix max_retries=0 (no retries) configuration option.
 
 ### Added
 - Add Console output plugin. #218

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -343,9 +343,17 @@ For example `packetbeat` generates `[packetbeat-]YYYY.MM.DD` indexes (for exampl
 
 ===== max_retries
 
-The number of times a particular Elasticsearch index operation will be attempted. If
-the indexing operation doesn't succeed after the specified number of retries, the events are
+The number of times to try a particular Logstash send attempt. If
+the send operation doesn't succeed after the specified number of retries, the events are
 dropped. The default is 3.
+
+A value of 0 disables retrying and a value <0 will enable infinite retry until
+events have been published.
+
+If an event is dropped by the output plugin, each Beat implementation must
+determine whether to drop the event or try sending it again. If the send
+operation doesn't succeed after
+max_retries, the Beat is optionally notified.
 
 ===== bulk_max_size
 
@@ -542,7 +550,12 @@ The number of times to try a particular Logstash send attempt. If
 the send operation doesn't succeed after the specified number of retries, the events are
 dropped. The default is 3.
 
-If an event is dropped by the output plugin, each Beat implementation must determine whether to drop the event or try sending it again. If the send operation doesn't succeed after
+A value of 0 disables retrying and a value <0 will enable infinite retry until
+events have been published.
+
+If an event is dropped by the output plugin, each Beat implementation must
+determine whether to drop the event or try sending it again. If the send
+operation doesn't succeed after
 max_retries, the Beat is optionally notified.
 
 

--- a/outputs/elasticsearch/output.go
+++ b/outputs/elasticsearch/output.go
@@ -90,6 +90,10 @@ func (out *elasticsearchOutput) init(
 	if config.Max_retries != nil {
 		maxRetries = *config.Max_retries
 	}
+	maxAttempts := maxRetries + 1 // maximum number of send attempts (-1 = infinite)
+	if maxRetries < 0 {
+		maxAttempts = 0
+	}
 
 	var waitRetry = time.Duration(1) * time.Second
 	var maxWaitRetry = time.Duration(60) * time.Second
@@ -98,15 +102,15 @@ func (out *elasticsearchOutput) init(
 	out.clients = clients
 	if len(clients) == 1 {
 		client := clients[0]
-		m, err = mode.NewSingleConnectionMode(client, maxRetries,
+		m, err = mode.NewSingleConnectionMode(client, maxAttempts,
 			waitRetry, timeout, maxWaitRetry)
 	} else {
 		loadBalance := config.LoadBalance == nil || *config.LoadBalance
 		if loadBalance {
-			m, err = mode.NewLoadBalancerMode(clients, maxRetries,
+			m, err = mode.NewLoadBalancerMode(clients, maxAttempts,
 				waitRetry, timeout, maxWaitRetry)
 		} else {
-			m, err = mode.NewFailOverConnectionMode(clients, maxRetries, waitRetry, timeout)
+			m, err = mode.NewFailOverConnectionMode(clients, maxAttempts, waitRetry, timeout)
 		}
 	}
 	if err != nil {

--- a/outputs/logstash/logstash.go
+++ b/outputs/logstash/logstash.go
@@ -99,18 +99,22 @@ func (lj *logstash) init(
 	if config.Max_retries != nil {
 		sendRetries = *config.Max_retries
 	}
+	maxAttempts := sendRetries + 1
+	if sendRetries < 0 {
+		maxAttempts = 0
+	}
 
 	var m mode.ConnectionMode
 	if len(clients) == 1 {
 		m, err = mode.NewSingleConnectionMode(clients[0],
-			sendRetries, waitRetry, timeout, maxWaitRetry)
+			maxAttempts, waitRetry, timeout, maxWaitRetry)
 	} else {
 		loadBalance := config.LoadBalance != nil && *config.LoadBalance
 		if loadBalance {
-			m, err = mode.NewLoadBalancerMode(clients, sendRetries,
+			m, err = mode.NewLoadBalancerMode(clients, maxAttempts,
 				waitRetry, timeout, maxWaitRetry)
 		} else {
-			m, err = mode.NewFailOverConnectionMode(clients, sendRetries, waitRetry, timeout)
+			m, err = mode.NewFailOverConnectionMode(clients, maxAttempts, waitRetry, timeout)
 		}
 	}
 	if err != nil {

--- a/outputs/mode/single.go
+++ b/outputs/mode/single.go
@@ -68,14 +68,17 @@ func (s *SingleConnectionMode) PublishEvents(
 	return s.publish(signaler, func() (bool, bool) {
 		for len(events) > 0 {
 			var err error
+
 			total := len(events)
 			events, err = s.conn.PublishEvents(events)
 			if err != nil {
 				logp.Info("Error publishing events (retrying): %s", err)
+
 				madeProgress := len(events) < total
 				return false, madeProgress
 			}
 		}
+
 		return true, false
 	})
 }


### PR DESCRIPTION
Output modes are configured with total number if send attempts, that is if
max_retries=0, total number of attempts = 1.

Also update output modes to handle failures and retries consistently for single
and bulk sends.