### PR TITLE
Cleanup the structure for the fields that identify a beat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ All notable changes to this project will be documented in this file based on the
 
 ### Backward Compatibility Breaks
 
+* The `shipper` output field is renamed to `beat.name`. #285
+
 ### Bugfixes
 
-
 ### Added
+
+* Added `beat.hostname` to contain the hostname where the Beat is running on as
+  returned by the operating system. #285
+* Added `beat.version` to contain the version of the Beat. #285
 
 ### Deprecated
 

--- a/beat/beat.go
+++ b/beat/beat.go
@@ -93,7 +93,7 @@ func (b *Beat) LoadConfig() {
 
 	logp.Debug("beat", "Initializing output plugins")
 
-	if err := publisher.Publisher.Init(b.Name, b.Config.Output, b.Config.Shipper); err != nil {
+	if err := publisher.Publisher.Init(b.Name, b.Version, b.Config.Output, b.Config.Shipper); err != nil {
 		logp.Critical(err.Error())
 		os.Exit(1)
 	}

--- a/publisher/preprocess.go
+++ b/publisher/preprocess.go
@@ -52,8 +52,12 @@ func (p *preprocessor) onMessage(m message) {
 			continue
 		}
 
-		// add additional meta data
-		event["shipper"] = publisher.name
+		// add additional Beat meta data
+		event["beat"] = common.MapStr{
+			"name":     publisher.name,
+			"hostname": publisher.hostname,
+			"version":  publisher.version,
+		}
 		if len(publisher.tags) > 0 {
 			event["tags"] = publisher.tags
 		}

--- a/publisher/publish.go
+++ b/publisher/publish.go
@@ -46,7 +46,10 @@ type TransactionalEventPublisher interface {
 }
 
 type PublisherType struct {
-	name           string
+	shipperName    string // Shipper name as set in the configuration file
+	hostname       string // Host name as returned by the operation system
+	name           string // The shipperName if configured, the hostname otherwise
+	version        string // The Beat version to include in the output docs
 	ipaddrs        []string
 	tags           []string
 	disabled       bool
@@ -164,7 +167,8 @@ func (publisher *PublisherType) PublishTopology(params ...string) error {
 }
 
 func (publisher *PublisherType) Init(
-	beat string,
+	beatName string,
+	version string,
 	configs map[string]outputs.MothershipConfig,
 	shipper ShipperConfig,
 ) error {
@@ -180,9 +184,10 @@ func (publisher *PublisherType) Init(
 
 	publisher.wsOutput.Init()
 	publisher.wsPublisher.Init()
+	publisher.version = version
 
 	if !publisher.disabled {
-		plugins, err := outputs.InitOutputs(beat, configs, shipper.Topology_expire)
+		plugins, err := outputs.InitOutputs(beatName, configs, shipper.Topology_expire)
 		if err != nil {
 			return err
 		}
@@ -234,16 +239,17 @@ func (publisher *PublisherType) Init(
 		}
 	}
 
-	publisher.name = shipper.Name
-	if len(publisher.name) == 0 {
-		// use the hostname
-		publisher.name, err = os.Hostname()
-		if err != nil {
-			return err
-		}
-
-		logp.Info("No shipper name configured, using hostname '%s'", publisher.name)
+	publisher.shipperName = shipper.Name
+	publisher.hostname, err = os.Hostname()
+	if err != nil {
+		return err
 	}
+	if len(publisher.shipperName) > 0 {
+		publisher.name = publisher.shipperName
+	} else {
+		publisher.name = publisher.hostname
+	}
+	logp.Info("Publisher name: %s", publisher.name)
 
 	publisher.tags = shipper.Tags
 


### PR DESCRIPTION
* The `shipper` field is renamed to `beat.name`
* A `beat.hostname` field is added that contains the hostname
* A `beat.version` field is added that contains the version

Closes #281.