### PR TITLE
Removing enabled as a configuration option for outputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file based on the
 ### Backward Compatibility Breaks
 
 * The `shipper` output field is renamed to `beat.name`. #285
+* Use of `enabled` as a configuration option for outputs (elasticsearch,
+  logstash, etc.) has been removed. #264
+* Use of `disabled` as a configuration option for tls has been removed. #264
 
 ### Bugfixes
 - Disable logging to stderr after configuration phase. #276

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -57,21 +57,21 @@ shipper:
 ===== name
 
 The name of the Beat. If this option is empty, the `hostname` of the server is
-used. The name is included as the `shipper` field in each published transaction. You can 
+used. The name is included as the `shipper` field in each published transaction. You can
 use the name to group all transactions sent by a single Beat.
 
-At startup, each Beat can publish its IP, port, and name to Elasticsearch. This information 
-is stored in Elasticsearch as a network topology map that maps the IP and port 
+At startup, each Beat can publish its IP, port, and name to Elasticsearch. This information
+is stored in Elasticsearch as a network topology map that maps the IP and port
 of each Beat to the name that you specify here.
 
-When a Beat receives a new request and response (called a transaction), the Beat can query  
-Elasticsearch to see if the network topology includes the IP and port of the source 
-and destination servers. If this information is available, the `client_server` field in the 
-output is set to the name of the Beat running on the source server, and the `server` field is set to the 
+When a Beat receives a new request and response (called a transaction), the Beat can query
+Elasticsearch to see if the network topology includes the IP and port of the source
+and destination servers. If this information is available, the `client_server` field in the
+output is set to the name of the Beat running on the source server, and the `server` field is set to the
 name of the Beat running on the destination server.
 
-To use the topology map in Elasticsearch, you must set <<save_topology>> 
-to true and enable Elasticsearch as output. 
+To use the topology map in Elasticsearch, you must set <<save_topology>>
+to true and enable Elasticsearch as output.
 
 Example:
 
@@ -83,9 +83,9 @@ shipper:
 
 ===== tags
 
-A list of tags that the Beat includes in the `tags` field of each published 
+A list of tags that the Beat includes in the `tags` field of each published
 transaction. Tags make it easy to group servers by different logical properties.
-For example, if you have a cluster of web servers, you can add the "webservers" tag 
+For example, if you have a cluster of web servers, you can add the "webservers" tag
 to the Beat on each server, and then use filters and queries in the
 Kibana web interface to get visualisations for the whole group of servers.
 
@@ -102,19 +102,19 @@ shipper:
 If the `ignore_outgoing` option is enabled, the Beat ignores all the
 transactions initiated from the server running the Beat.
 
-This is useful when two Beats publish the same transactions. Because one Beat  
-sees the transaction in its outgoing queue and the other sees it in its incoming 
-queue, you can end up with duplicate transactions. To remove the duplicates, you 
+This is useful when two Beats publish the same transactions. Because one Beat
+sees the transaction in its outgoing queue and the other sees it in its incoming
+queue, you can end up with duplicate transactions. To remove the duplicates, you
 can enable the `ignore_outgoing` option on one of the servers.
 
-For example, in the following scenario, you see a 3-server architecture 
-where a Beat is installed on each server. t1 is the transaction exchanged between 
-Server1 and Server2, and t2 is the transaction between Server2 and Server3. 
+For example, in the following scenario, you see a 3-server architecture
+where a Beat is installed on each server. t1 is the transaction exchanged between
+Server1 and Server2, and t2 is the transaction between Server2 and Server3.
 
 image:./images/option_ignore_outgoing.png[Beats Architecture]
 
-By default, each transaction is indexed twice because Beat2 
-sees both transactions. So you would see the following published transactions 
+By default, each transaction is indexed twice because Beat2
+sees both transactions. So you would see the following published transactions
 (when `ignore_outgoing` is false):
 
  - Beat1: t1
@@ -122,7 +122,7 @@ sees both transactions. So you would see the following published transactions
  - Beat3: t2
 
 To avoid duplicates, you can force your Beats to send only the incoming
-transactions and ignore the transactions created by the local server. So you would 
+transactions and ignore the transactions created by the local server. So you would
 see the following published transactions (when `ignore_outgoing` is true):
 
  - Beat1: none
@@ -132,7 +132,7 @@ see the following published transactions (when `ignore_outgoing` is true):
 ===== refresh_topology_freq
 
 The refresh interval of the topology map in
-seconds. In other words, this setting specifies how often each Beat publishes its 
+seconds. In other words, this setting specifies how often each Beat publishes its
 IP addresses to the topology map. The default is 10 seconds.
 
 ===== topology_expire
@@ -144,7 +144,7 @@ is 15 seconds.
 
 ===== geoip.paths
 
-The paths to search for GeoIP databases. The Beat loads the first installed GeoIP database that if finds. Then, for each transaction, the Beat exports the GeoIP location of the client.  
+The paths to search for GeoIP databases. The Beat loads the first installed GeoIP database that if finds. Then, for each transaction, the Beat exports the GeoIP location of the client.
 
 If no value is specified for geoip.paths, the default paths `/usr/share/GeoIP/GeoLiteCity.dat` and `/usr/local/var/GeoIP/GeoLiteCity.dat` are searched for installed GeoIP databases.
 
@@ -179,10 +179,6 @@ Example configuration:
 ------------------------------------------------------------------------------
 output:
   elasticsearch:
-
-    # Enable Elasticsearch as output
-    enabled: true
-
     # The Elasticsearch cluster
     hosts: ["http://localhost:9200"]
 
@@ -215,10 +211,6 @@ To enable SSL, just add `https` to all URLs defined under __hosts__.
 
 output:
   elasticsearch:
-	
-    # Enable Elasticsearch as output
-    enabled: true
-
     # The Elasticsearch cluster
     hosts: ["https://localhost:9200"]
 
@@ -240,10 +232,6 @@ If the Elasticsearch nodes are defined by `IP:PORT`, then add `protocol: https` 
 
 output:
   elasticsearch:
-
-    # Enable Elasticsearch as output
-    enabled: true
-
     # The Elasticsearch cluster
     hosts: ["localhost"]
 
@@ -262,10 +250,6 @@ output:
 ------------------------------------------------------------------------------
 
 
-===== enabled
-
-A Boolean option that enables Elasticsearch as output. The default is true.
-
 [[hosts-option]]
 ===== hosts
 
@@ -275,17 +259,13 @@ automatically sent to another node. Each Elasticsearch node can be defined as a 
 For example: `http://192.15.3.2`, `https://es.found.io:9230` or `192.24.3.2:9300`.
 If no port is specified, `9200` is used.
 
-NOTE: When a node is defined as an `IP:PORT`, the _scheme_ and _path_ are taken from the 
-<<protocol-option>> and <<path-option>> config options. 
+NOTE: When a node is defined as an `IP:PORT`, the _scheme_ and _path_ are taken from the
+<<protocol-option>> and <<path-option>> config options.
 
 [source,yaml]
 ------------------------------------------------------------------------------
 output:
   elasticsearch:
-
-    # Enable Elasticsearch as output
-    enabled: true
-
     # The Elasticsearch cluster
     hosts: ["10.45.3.2:9220", "10.45.3.1:9230"]
 
@@ -325,9 +305,9 @@ The basic authentication password for connecting to Elasticsearch.
 ===== protocol
 
 The name of the protocol Elasticsearch is reachable on. The options are:
-`http` or `https`. The default is `http`. However, if you specify a URL for 
-<<hosts-option>>, the value of protocol is overridden by whatever scheme you 
-specify in the URL. 
+`http` or `https`. The default is `http`. However, if you specify a URL for
+<<hosts-option>>, the value of protocol is overridden by whatever scheme you
+specify in the URL.
 
 [[path-option]]
 ===== path
@@ -383,7 +363,7 @@ Elasticsearch. The default is 15 seconds.
 
 ===== tls
 
-Configuration options for TLS parameters like the certificate authority to use 
+Configuration options for TLS parameters like the certificate authority to use
 for HTTPS-based connections. If the tls section is missing, the host CAs are used for HTTPS connections to
 Elasticsearch.
 
@@ -394,7 +374,7 @@ See <<configuration-output-tls>> for more information.
 ==== Logstash Output
 
 The Logstash output sends the events directly to Logstash by using the lumberjack
-protocol. To use this option, you must <<logstash-setup, install and configure>> the logstash-input-beats 
+protocol. To use this option, you must <<logstash-setup, install and configure>> the logstash-input-beats
 plugin in Logstash. Logstash allows for additional processing and routing of
 generated events.
 
@@ -466,28 +446,19 @@ Here is an example of how to configure the Beat to use Logstash:
 ------------------------------------------------------------------------------
 output:
   logstash:
-    enabled: true
-
     hosts: ["localhost:5044"]
 
     # index configures '@metadata.beat' field to be used by Logstash for
     # indexing. By Default the beat name is used (e.g. filebeat, topbeat, packetbeat)
     index: mybeat
-
-    tls:
-      # disable tls for testing (TLS must be disabled in logstash too)
-      disabled: true
 ------------------------------------------------------------------------------
 
-===== enabled
-
-A Boolean option that enables Logstash output. The default is true.
 
 [[hosts]]
 ===== hosts
 
 The list of known Logstash servers to connect to. All entries in this list can
-contain a port number. If no port number is given, the value specified for <<port>> 
+contain a port number. If no port number is given, the value specified for <<port>>
 is used as the default port number.
 
 ===== worker
@@ -499,17 +470,15 @@ is best used with load balancing mode enabled. Example: If you have 2 hosts and
 [[loadbalance]]
 ===== loadbalance
 
-If set to true and multiple Logstash hosts are configured, the output plugin 
+If set to true and multiple Logstash hosts are configured, the output plugin
 load balances published events onto all Logstash hosts. If set to false,
-the output plugin sends all events to only one host (determined at random) and 
+the output plugin sends all events to only one host (determined at random) and
 will switch to another host if the selected one becomes unresponsive. The default value is false.
 
 [source,yaml]
 ------------------------------------------------------------------------------
 output:
   logstash:
-    enabled: true
-
     hosts: ["localhost:5044", "localhost:5045"]
 
     # configure index prefix name
@@ -517,10 +486,6 @@ output:
 
     # configure logstash plugin to loadbalance events between the logstash instances
     loadbalance: true
-
-    tls:
-      # disable tls for testing (TLS must be disabled in logstash too)
-      disabled: true
 ------------------------------------------------------------------------------
 
 [[port]]
@@ -537,7 +502,7 @@ For example `packetbeat` generates `[packetbeat-]YYYY.MM.DD` indexes (for exampl
 ===== tls
 
 Configuration options for TLS parameters like the root CA for Logstash connections. See
-<<configuration-output-tls>> for more information. If the tls section is missing or tls.disabled is set to true, a TCP-only connection is assumed. Logstash must also be configured to use TCP for 
+<<configuration-output-tls>> for more information. If the tls section is missing, a TCP-only connection is assumed. Logstash must also be configured to use TCP for
 Logstash input.
 
 ===== timeout
@@ -564,18 +529,14 @@ max_retries, the Beat is optionally notified.
 
 The Redis output inserts the events in a Redis list. This output plugin is compatible with
 the http://logstash.net/docs/1.4.2/inputs/redis[Redis input plugin] from Logstash,
-so the Redis Output for the Beats is deprecated. 
+so the Redis Output for the Beats is deprecated.
 
 Example configuration:
 
 [source,yaml]
 ------------------------------------------------------------------------------
 output:
-
   redis:
-    # Uncomment out this option if you want to output to Redis. The default is false.
-    enabled: true
-
     # Set the host and port where to find Redis.
     host: "localhost"
     port: 6379
@@ -608,10 +569,6 @@ output:
     reconnect_interval: 1
 ------------------------------------------------------------------------------
 
-
-===== enabled
-
-A Boolean option that enables Redis as output. The default is false.
 
 ===== host
 
@@ -659,7 +616,6 @@ output:
   # rotate_every_kb: maximum size of the files in path
   # number of files: maximum number of files in path
   file:
-    enabled: true
     path: "/tmp/packetbeat"
     filename: packetbeat
     rotate_every_kb: 1000
@@ -670,10 +626,6 @@ The file output dumps the transactions into a file where each transaction is in 
 Currently, this output is used for testing, but it can be used as input for
 Logstash.
 
-===== enabled
-
-A Boolean option that enables File as output. The default is false.
-
 [[path]]
 ===== path
 
@@ -682,7 +634,7 @@ mandatory.
 
 ===== filename
 
-The name of the generated files. The default is set to Beat name. For example, the files 
+The name of the generated files. The default is set to Beat name. For example, the files
 generated by default for Packetbeat would be `packetbeat`, `packetbeat.1`, `packetbeat.2`, and so on.
 
 ===== rotate_every_kb
@@ -702,16 +654,10 @@ is 7 files.
 ------------------------------------------------------------------------------
 output:
   console:
-    enabled: true
-
     pretty: true
 ------------------------------------------------------------------------------
 
 The Console output write events in JSON format to stdout.
-
-===== enabled
-
-Boolean option that enables Console as output. The default is false.
 
 ===== pretty
 
@@ -720,10 +666,6 @@ If pretty is set events written to stdout will be nicely formatted. The default 
 [[configuration-output-tls]]
 
 ==== TLS options
-
-===== disabled
-
-When set to true, none of the TLS configuration options will be applied. The effect is similar to a missing TLS configuration in the output plugin.
 
 ===== certificate_authorities
 
@@ -736,7 +678,7 @@ The list of root certificates for server verifications. If certificate_authoriti
 The path to the certificate for TLS client authentication. If the certificate
 is not specified, client authentication is not available. The connection
 might fail if the server requests client authentication. If the TLS server does not
-require client authentication, the certificate will be loaded, but not requested or used 
+require client authentication, the certificate will be loaded, but not requested or used
 by the server.
 
 When this option is configured, the <<certificate_key>> option is also required.
@@ -763,7 +705,7 @@ The default value is `1.2`.
 ===== insecure
 
 This option controls whether the client verifies server certificates and host names.
-If insecure is set to true, all server host names and certificates are 
+If insecure is set to true, all server host names and certificates are
 accepted. In this mode, TLS-based connections are susceptible to
 man-in-the-middle attacks. Use this option for testing only.
 
@@ -867,7 +809,7 @@ value is true.
 
 ===== to_files
 
-Writes all logging output to files subject to file rotation. On Windows systems, the 
+Writes all logging output to files subject to file rotation. On Windows systems, the
 default value is true.
 
 ===== level
@@ -892,7 +834,7 @@ non-Windows systems is `/var/log/<beat-name>`.
 
 ===== files.name
 
-The name of the file that logs are written to. By default, the name of the Beat 
+The name of the file that logs are written to. By default, the name of the Beat
 is used.
 
 ===== files.rotateeverybytes

--- a/docs/gettingstarted.asciidoc
+++ b/docs/gettingstarted.asciidoc
@@ -173,8 +173,6 @@ output and use the <<logstash-output,Logstash output>> instead:
 ------------------------------------------------------------------------------
 output:
   logstash:
-    enabled: true
-
     hosts: ["127.0.0.1:5044"]
 
     # configure logstash plugin to loadbalance events between

--- a/docs/https.asciidoc
+++ b/docs/https.asciidoc
@@ -6,7 +6,6 @@ and basic authentication. Here is an sample configuration:
 [source,yaml]
 ----
 elasticsearch:
-  enabled: true
   username: packetbeat <1>
   password: verysecret <2>
   protocol: https <3>
@@ -36,7 +35,6 @@ CA certificates instead of the list from the OS. Here is an example:
 [source,yaml]
 ----
 elasticsearch:
-  enabled: true
   username: packetbeat
   password: verysecret
   protocol: https

--- a/etc/libbeat.yml
+++ b/etc/libbeat.yml
@@ -5,15 +5,11 @@
 ############################# Output ##########################################
 
 # Configure what outputs to use when sending the data collected by the beat.
-# You can enable one or multiple outputs by setting enabled option to true.
+# Multiple outputs may be used. 
 output:
 
   ### Elasticsearch as output
   elasticsearch:
-
-    # Set to true to enable elasticsearch output
-    enabled: true
-
     # Array of hosts to connect to.
     # Scheme and port can be left out and will be set to the default (http and 9200)
     # In case you specify and additional path, the scheme is required: http://localhost:9200/path
@@ -50,22 +46,18 @@ output:
     # The number of seconds to wait for new events between two bulk API index requests.
     # If `bulk_max_size` is reached before this interval expires, addition bulk index
     # requests are made.
-    #flush_interval
+    #flush_interval: 1
 
     # Boolean that sets if the topology is kept in Elasticsearch. The default is
     # false. This option makes sense only for Packetbeat.
-    #save_topology:
+    #save_topology: false
 
-    #The time to live in seconds for the topology information that is stored in
-    #Elasticsearch. The default is 15 seconds.
-    #topology_expire:
+    # The time to live in seconds for the topology information that is stored in
+    # Elasticsearch. The default is 15 seconds.
+    #topology_expire: 15
 
     # tls configuration. By default is off.
     #tls:
-      # If disabled is set to true, the tls section will be ignored and the
-      # host its certificate authorities will be used.
-      #disabled: true
-
       # List of root certificates for HTTPS server verifications
       #certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -93,12 +85,9 @@ output:
       # Configure maximum TLS version allowed for connection to logstash
       #max_version: 1.2
 
+
   ### Logstash as output
-
   #logstash:
-    # Uncomment out this option if you want to output to Logstash. The default is false.
-    #enabled: true
-
     # The Logstash hosts
     #hosts: ["localhost:5044"]
 
@@ -115,8 +104,6 @@ output:
 
     # Optional TLS. By default is off.
     #tls:
-      #disabled: true
-
       # List of root certificates for HTTPS server verifications
       #certificate_authorities: ["/etc/pki/root/ca.pem"]
 
@@ -139,12 +126,8 @@ output:
       #curve_types: []
 
 
-
   ### File as output
   #file:
-    # Enabling file output
-    #enabled: false
-
     # Path to the directory where to save the generated files. The option is mandatory.
     #path: "/tmp/beatname"
 
@@ -160,12 +143,10 @@ output:
     # is 7 files.
     #number_of_files: 7
 
+
   ### Console output
   # console:
-    # Enabling console output
-    #enabled: false
-
-    # pretty print json event
+    # Pretty print json event
     #pretty: false
 
 

--- a/outputs/elasticsearch/output_test.go
+++ b/outputs/elasticsearch/output_test.go
@@ -23,7 +23,6 @@ func createElasticsearchConnection(flushInterval int, bulkSize int) elasticsearc
 
 	var output elasticsearchOutput
 	output.init("packetbeat", outputs.MothershipConfig{
-		Enabled:        true,
 		Save_topology:  true,
 		Host:           GetEsHost(),
 		Port:           esPort,

--- a/outputs/logstash/logstash.go
+++ b/outputs/logstash/logstash.go
@@ -57,11 +57,7 @@ func (lj *logstash) init(
 	config outputs.MothershipConfig,
 	topologyExpire int,
 ) error {
-	useTLS := false
-	if config.TLS != nil {
-		useTLS = !config.TLS.Disabled
-	}
-
+	useTLS := (config.TLS != nil)
 	timeout := logstashDefaultTimeout
 	if config.Timeout != 0 {
 		timeout = time.Duration(config.Timeout) * time.Second

--- a/outputs/logstash/logstash_integration_test.go
+++ b/outputs/logstash/logstash_integration_test.go
@@ -114,10 +114,9 @@ func testElasticsearchIndex(test string) string {
 
 func newTestLogstashOutput(t *testing.T, test string, tls bool) *testOutputer {
 	config := &outputs.MothershipConfig{
-		Enabled: true,
-		Hosts:   []string{getLogstashHost()},
-		TLS:     nil,
-		Index:   testLogstashIndex(test),
+		Hosts: []string{getLogstashHost()},
+		TLS:   nil,
+		Index: testLogstashIndex(test),
 	}
 	if tls {
 		config.Hosts = []string{getLogstashTLSHost()}
@@ -151,7 +150,6 @@ func newTestElasticsearchOutput(t *testing.T, test string) *testOutputer {
 	flushInterval := 0
 	bulkSize := 0
 	config := outputs.MothershipConfig{
-		Enabled:        true,
 		Hosts:          []string{getElasticsearchHost()},
 		Index:          index,
 		Flush_interval: &flushInterval,

--- a/outputs/logstash/logstash_test.go
+++ b/outputs/logstash/logstash_test.go
@@ -142,10 +142,9 @@ func newTestLumberjackOutput(
 ) outputs.BulkOutputer {
 	if config == nil {
 		config = &outputs.MothershipConfig{
-			Enabled: true,
-			TLS:     nil,
-			Hosts:   []string{getLogstashHost()},
-			Index:   testLogstashIndex(test),
+			TLS:   nil,
+			Hosts: []string{getLogstashHost()},
+			Index: testLogstashIndex(test),
 		}
 
 	}

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -8,7 +8,6 @@ import (
 )
 
 type MothershipConfig struct {
-	Enabled            bool
 	Save_topology      bool
 	Host               string
 	Port               int
@@ -97,7 +96,7 @@ func InitOutputs(
 	var plugins []OutputPlugin = nil
 	for name, plugin := range enabledOutputPlugins {
 		config, exists := configs[name]
-		if !exists || !config.Enabled {
+		if !exists {
 			continue
 		}
 

--- a/outputs/tls.go
+++ b/outputs/tls.go
@@ -32,7 +32,6 @@ var (
 
 // TLSConfig defines config file options for TLS clients.
 type TLSConfig struct {
-	Disabled       bool     `yaml:"disabled"`
 	Certificate    string   `yaml:"certificate"`
 	CertificateKey string   `yaml:"certificate_key"`
 	CAs            []string `yaml:"certificate_authorities"`
@@ -48,7 +47,7 @@ type TLSConfig struct {
 // will be configured. If no CAs are configured, the host CA will be used by go
 // built-in TLS support.
 func LoadTLSConfig(config *TLSConfig) (*tls.Config, error) {
-	if config == nil || config.Disabled {
+	if config == nil {
 		return nil, nil
 	}
 

--- a/outputs/tls_test.go
+++ b/outputs/tls_test.go
@@ -23,7 +23,6 @@ func TestEmptyTlsConfig(t *testing.T) {
 	cfg, err := load("")
 	assert.Nil(t, err)
 
-	assert.Equal(t, false, cfg.Disabled)
 	assert.Equal(t, "", cfg.Certificate)
 	assert.Equal(t, "", cfg.CertificateKey)
 	assert.Len(t, cfg.CAs, 0)
@@ -49,7 +48,6 @@ func TestLoadWithEmptyValues(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, false, cfg.Disabled)
 	assert.Equal(t, "", cfg.Certificate)
 	assert.Equal(t, "", cfg.CertificateKey)
 	assert.Len(t, cfg.CAs, 0)
@@ -78,7 +76,6 @@ func TestValuesSet(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, true, cfg.Disabled)
 	assert.Equal(t, "mycert.pem", cfg.Certificate)
 	assert.Equal(t, "mycert.key", cfg.CertificateKey)
 	assert.Len(t, cfg.CAs, 2)
@@ -91,12 +88,6 @@ func TestValuesSet(t *testing.T) {
 
 func TestNoLoadNilConfig(t *testing.T) {
 	cfg, err := LoadTLSConfig(nil)
-	assert.Nil(t, err)
-	assert.Nil(t, cfg)
-}
-
-func TestNoLoadDisabled(t *testing.T) {
-	cfg, err := LoadTLSConfig(&TLSConfig{Disabled: true})
 	assert.Nil(t, err)
 	assert.Nil(t, cfg)
 }
@@ -116,7 +107,6 @@ func TestApplyEmptyConfig(t *testing.T) {
 
 func TestApplyWithConfig(t *testing.T) {
 	cfg, err := LoadTLSConfig(&TLSConfig{
-		Disabled:       false,
 		Certificate:    "logstash/ca_test.pem",
 		CertificateKey: "logstash/ca_test.key",
 		CAs:            []string{"logstash/ca_test.pem"},

--- a/tests/system/config/mockbeat.yml.j2
+++ b/tests/system/config/mockbeat.yml.j2
@@ -34,7 +34,7 @@ shipper:
 ############################# Output ############################################
 
 # Configure what outputs to use when sending the data collected by packetbeat.
-# You can enable one or multiple outputs by setting enabled option to true.
+# Multiple outputs may be enabled.
 output:
 
   # Elasticsearch as output
@@ -42,7 +42,6 @@ output:
   # host, port: where Elasticsearch is listening on
   # save_topology: specify if the topology is saved in Elasticsearch
   #elasticsearch:
-  #  enabled: false
   #  host: localhost
   #  port: 9200
   #  save_topology: true
@@ -52,7 +51,6 @@ output:
   # host, port: where Redis is listening on
   # save_topology: specify if the topology is saved in Redis
   #redis:
-  #  enabled: false
   #  host: localhost
   #  port: 6379
   #  save_topology: true
@@ -64,7 +62,6 @@ output:
   # rotate_every_kb: maximum size of the files in path
   # number of files: maximum number of files in path
   file:
-    enabled: true
     path: {{ output_file_path|default(fb.working_dir + "/output") }}
     filename: "{{ output_file_filename|default("mockbeat") }}"
     rotate_every_kb: 1000


### PR DESCRIPTION
Removing disabled as a configuration opation for tls configuration.
Use comments in config file to enable and disable. #264

Suggested diff view: [Ignore trailing whitespace](https://github.com/elastic/libbeat/pull/295/files?w=1) (the docs had a lot of trailing whitespace)