### PR TITLE
Bug/226 logstash record loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 - Disable logging to stderr after configuration phase. #276
 - Set the default file logging path when not set in config. #275
+- Fix bug silently dropping records based on current window size. elastic/filebeat#226
 
 ### Added
 

--- a/outputs/elasticsearch/client.go
+++ b/outputs/elasticsearch/client.go
@@ -63,6 +63,9 @@ func (client *Client) Clone() *Client {
 	return newClient
 }
 
+// PublishEvents sends all events to elasticsearch. On error a slice with all
+// events not published or confirmed to be processed by elasticsearch will be
+// returned. The input slice backing memory will be reused by return the value.
 func (client *Client) PublishEvents(
 	events []common.MapStr,
 ) ([]common.MapStr, error) {

--- a/outputs/logstash/client.go
+++ b/outputs/logstash/client.go
@@ -29,7 +29,6 @@ type lumberjackClient struct {
 	countTimeoutErr int
 }
 
-// TODO: make max window size configurable
 const (
 	minWindowSize             int = 1
 	defaultStartMaxWindowSize int = 10

--- a/outputs/logstash/client.go
+++ b/outputs/logstash/client.go
@@ -32,8 +32,7 @@ type lumberjackClient struct {
 const (
 	minWindowSize             int = 1
 	defaultStartMaxWindowSize int = 10
-
-	maxAllowedTimeoutErr int = 3
+	maxAllowedTimeoutErr      int = 3
 )
 
 // errors
@@ -69,6 +68,8 @@ func (l *lumberjackClient) PublishEvent(event common.MapStr) error {
 	return err
 }
 
+// PublishEvents sends all events to logstash. On error a slice with all events
+// not published or confirmed to be processed by logstash will be returned.
 func (l *lumberjackClient) PublishEvents(
 	events []common.MapStr,
 ) ([]common.MapStr, error) {

--- a/outputs/logstash/client_test.go
+++ b/outputs/logstash/client_test.go
@@ -296,9 +296,12 @@ func sendAck(transp *mockTransport, seq uint32) {
 	transp.sendBytes(buf.Bytes())
 }
 
+const testMaxWindowSize = 64
+
 func TestSendZero(t *testing.T) {
 	transp := newMockTransport()
-	client := newClientTestDriver(newLumberjackClient(transp, 5*time.Second))
+	client := newClientTestDriver(
+		newLumberjackClient(transp, testMaxWindowSize, 5*time.Second))
 
 	client.Publish(make([]common.MapStr, 0))
 
@@ -312,7 +315,8 @@ func TestSendZero(t *testing.T) {
 
 func TestSimpleEvent(t *testing.T) {
 	transp := newMockTransport()
-	client := newClientTestDriver(newLumberjackClient(transp, 5*time.Second))
+	client := newClientTestDriver(
+		newLumberjackClient(transp, testMaxWindowSize, 5*time.Second))
 
 	event := common.MapStr{"name": "me", "line": 10}
 	client.Publish([]common.MapStr{event})
@@ -344,7 +348,8 @@ func TestSimpleEvent(t *testing.T) {
 
 func TestStructuredEvent(t *testing.T) {
 	transp := newMockTransport()
-	client := newClientTestDriver(newLumberjackClient(transp, 5*time.Second))
+	client := newClientTestDriver(
+		newLumberjackClient(transp, testMaxWindowSize, 5*time.Second))
 	event := common.MapStr{
 		"name": "test",
 		"struct": common.MapStr{

--- a/outputs/logstash/logstash_integration_test.go
+++ b/outputs/logstash/logstash_integration_test.go
@@ -332,6 +332,28 @@ func TestSendMultipleBigBatchesViaLogstashTLS(t *testing.T) {
 }
 
 func testSendMultipleBigBatchesViaLogstash(t *testing.T, name string, tls bool) {
+	testSendMultipleBatchesViaLogstash(t, name, 15, 128, tls)
+}
+
+func TestSendMultipleSmallBatchesViaLogstashTCP(t *testing.T) {
+	testSendMultipleSmallBatchesViaLogstash(t, "multiple-small-tcp", false)
+}
+
+func TestSendMultipleSmallBatchesViaLogstashTLS(t *testing.T) {
+	testSendMultipleSmallBatchesViaLogstash(t, "multiple-small-tls", true)
+}
+
+func testSendMultipleSmallBatchesViaLogstash(t *testing.T, name string, tls bool) {
+	testSendMultipleBatchesViaLogstash(t, name, 15, 16, tls)
+}
+
+func testSendMultipleBatchesViaLogstash(
+	t *testing.T,
+	name string,
+	numBatches int,
+	batchSize int,
+	tls bool,
+) {
 	if testing.Short() {
 		t.Skip("Skipping in short mode. Requires Logstash and Elasticsearch")
 	}
@@ -339,8 +361,6 @@ func testSendMultipleBigBatchesViaLogstash(t *testing.T, name string, tls bool) 
 	ls := newTestLogstashOutput(t, name, tls)
 	defer ls.Cleanup()
 
-	numBatches := 15
-	batchSize := 64
 	batches := make([][]common.MapStr, 0, numBatches)
 	for i := 0; i < numBatches; i++ {
 		batch := make([]common.MapStr, 0, batchSize)

--- a/outputs/logstash/logstash_integration_test.go
+++ b/outputs/logstash/logstash_integration_test.go
@@ -113,10 +113,13 @@ func testElasticsearchIndex(test string) string {
 }
 
 func newTestLogstashOutput(t *testing.T, test string, tls bool) *testOutputer {
+	windowSize := 32
+
 	config := &outputs.MothershipConfig{
-		Hosts: []string{getLogstashHost()},
-		TLS:   nil,
-		Index: testLogstashIndex(test),
+		Hosts:       []string{getLogstashHost()},
+		TLS:         nil,
+		Index:       testLogstashIndex(test),
+		BulkMaxSize: &windowSize,
 	}
 	if tls {
 		config.Hosts = []string{getLogstashTLSHost()}
@@ -337,7 +340,7 @@ func testSendMultipleBigBatchesViaLogstash(t *testing.T, name string, tls bool) 
 	defer ls.Cleanup()
 
 	numBatches := 15
-	batchSize := 256
+	batchSize := 64
 	batches := make([][]common.MapStr, 0, numBatches)
 	for i := 0; i < numBatches; i++ {
 		batch := make([]common.MapStr, 0, batchSize)
@@ -361,7 +364,8 @@ func testSendMultipleBigBatchesViaLogstash(t *testing.T, name string, tls bool) 
 	}
 
 	// wait for logstash event flush + elasticsearch
-	waitUntilTrue(5*time.Second, checkIndex(ls, numBatches*batchSize))
+	ok := waitUntilTrue(5*time.Second, checkIndex(ls, numBatches*batchSize))
+	assert.True(t, ok) // check number of events matches total number of events
 
 	// search value in logstash elasticsearch index
 	resp, err := ls.Read()

--- a/outputs/logstash/logstash_integration_test.go
+++ b/outputs/logstash/logstash_integration_test.go
@@ -20,6 +20,8 @@ const (
 
 	elasticsearchDefaultHost = "localhost"
 	elasticsearchDefaultPort = "9200"
+
+	integrationTestWindowSize = 32
 )
 
 type esConnection struct {
@@ -113,7 +115,7 @@ func testElasticsearchIndex(test string) string {
 }
 
 func newTestLogstashOutput(t *testing.T, test string, tls bool) *testOutputer {
-	windowSize := 32
+	windowSize := integrationTestWindowSize
 
 	config := &outputs.MothershipConfig{
 		Hosts:       []string{getLogstashHost()},
@@ -332,7 +334,7 @@ func TestSendMultipleBigBatchesViaLogstashTLS(t *testing.T) {
 }
 
 func testSendMultipleBigBatchesViaLogstash(t *testing.T, name string, tls bool) {
-	testSendMultipleBatchesViaLogstash(t, name, 15, 128, tls)
+	testSendMultipleBatchesViaLogstash(t, name, 15, 4*integrationTestWindowSize, tls)
 }
 
 func TestSendMultipleSmallBatchesViaLogstashTCP(t *testing.T) {
@@ -344,7 +346,7 @@ func TestSendMultipleSmallBatchesViaLogstashTLS(t *testing.T) {
 }
 
 func testSendMultipleSmallBatchesViaLogstash(t *testing.T, name string, tls bool) {
-	testSendMultipleBatchesViaLogstash(t, name, 15, 16, tls)
+	testSendMultipleBatchesViaLogstash(t, name, 15, integrationTestWindowSize/2, tls)
 }
 
 func testSendMultipleBatchesViaLogstash(


### PR DESCRIPTION
Resolves elastic/filebeat#226

- make logstash window size configurable based on bulk_max_size config file option
- fix integration test testSendMultipleBigBatchesViaLogstash which was supposed to find this kind of issue (after fix error was reproducible)
- refactor logstash publishing to correctly return unprocessed events on failures only
