### PR TITLE
Bug/228 race in test

### DIFF
--- a/publisher/common_test.go
+++ b/publisher/common_test.go
@@ -2,6 +2,7 @@ package publisher
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/elastic/libbeat/common"
@@ -13,7 +14,7 @@ import (
 type testMessageHandler struct {
 	msgs     chan message   // Channel that hold received messages.
 	response OutputResponse // Response type to give to received messages.
-	stopped  bool           // Indicates if the messageHandler has been stopped.
+	stopped  uint32         // Indicates if the messageHandler has been stopped.
 }
 
 var _ messageHandler = &testMessageHandler{}
@@ -25,7 +26,7 @@ func (mh *testMessageHandler) onMessage(m message) {
 }
 
 func (mh *testMessageHandler) onStop() {
-	mh.stopped = true
+	atomic.AddUint32(&mh.stopped, 1)
 }
 
 func (mh *testMessageHandler) send(m message) {

--- a/publisher/worker.go
+++ b/publisher/worker.go
@@ -60,9 +60,9 @@ func (p *messageWorker) run() {
 }
 
 func (p *messageWorker) shutdown() {
+	p.handler.onStop()
 	stopQueue(p.queue)
 	p.ws.wg.Done()
-	p.handler.onStop()
 }
 
 func (p *messageWorker) send(m message) {

--- a/publisher/worker_test.go
+++ b/publisher/worker_test.go
@@ -3,6 +3,7 @@
 package publisher
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func TestMessageWorkerSend(t *testing.T) {
 	// Verify that stopping workerSignal causes a onStop notification
 	// in the messageHandler.
 	ws.stop()
-	assert.True(t, mh.stopped)
+	assert.True(t, atomic.LoadUint32(&mh.stopped) == 1)
 }
 
 // Test that stopQueue invokes the Failed callback on all events in the queue.


### PR DESCRIPTION
resolve #288

Could not recreate the race its trace locally, but when running test in a loop it occasionally failed.