### PR TITLE
correctly determine direction of transaction

### DIFF
--- a/publisher/preprocess.go
+++ b/publisher/preprocess.go
@@ -153,11 +153,11 @@ func updateEventAddresses(publisher *PublisherType, event common.MapStr) bool {
 
 		//get the direction of the transaction: outgoing (as client)/incoming (as server)
 		if publisher.IsPublisherIP(dst.Ip) {
-			// outgoing transaction
-			event["direction"] = "out"
-		} else {
-			//incoming transaction
+			// incoming transaction
 			event["direction"] = "in"
+		} else {
+			//outgoing transaction
+			event["direction"] = "out"
 		}
 	}
 


### PR DESCRIPTION
refer to bug #300 
This PR determines the direction of transaction correctly. Needs to be pushed to the rc1 branch.