### PR TITLE
Remove beat.version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ All notable changes to this project will be documented in this file based on the
 
 - Added `beat.hostname` to contain the hostname where the Beat is running on as
   returned by the operating system. #285
-- Added `beat.version` to contain the version of the Beat. #285
 - Added timestamp for file logging. #291
 
 ### Deprecated

--- a/beat/beat.go
+++ b/beat/beat.go
@@ -96,7 +96,7 @@ func (b *Beat) LoadConfig() {
 
 	logp.Debug("beat", "Initializing output plugins")
 
-	if err := publisher.Publisher.Init(b.Name, b.Version, b.Config.Output, b.Config.Shipper); err != nil {
+	if err := publisher.Publisher.Init(b.Name, b.Config.Output, b.Config.Shipper); err != nil {
 		fmt.Printf("Error Initialising publisher: %v\n", err)
 		logp.Critical(err.Error())
 		os.Exit(1)

--- a/publisher/preprocess.go
+++ b/publisher/preprocess.go
@@ -56,7 +56,6 @@ func (p *preprocessor) onMessage(m message) {
 		event["beat"] = common.MapStr{
 			"name":     publisher.name,
 			"hostname": publisher.hostname,
-			"version":  publisher.version,
 		}
 		if len(publisher.tags) > 0 {
 			event["tags"] = publisher.tags

--- a/publisher/publish.go
+++ b/publisher/publish.go
@@ -49,7 +49,6 @@ type PublisherType struct {
 	shipperName    string // Shipper name as set in the configuration file
 	hostname       string // Host name as returned by the operation system
 	name           string // The shipperName if configured, the hostname otherwise
-	version        string // The Beat version to include in the output docs
 	ipaddrs        []string
 	tags           []string
 	disabled       bool
@@ -168,7 +167,6 @@ func (publisher *PublisherType) PublishTopology(params ...string) error {
 
 func (publisher *PublisherType) Init(
 	beatName string,
-	version string,
 	configs map[string]outputs.MothershipConfig,
 	shipper ShipperConfig,
 ) error {
@@ -184,7 +182,6 @@ func (publisher *PublisherType) Init(
 
 	publisher.wsOutput.Init()
 	publisher.wsPublisher.Init()
-	publisher.version = version
 
 	if !publisher.disabled {
 		plugins, err := outputs.InitOutputs(beatName, configs, shipper.Topology_expire)


### PR DESCRIPTION
After discussing it some more, we didn't have a clear use case for the version, and it's easier to add it in the future than remove it, so we prefer to do it before the GA.