### PR TITLE
Elasticsearch bulk error response message support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file based on the
 - Set the default file logging path when not set in config. #275
 - Fix bug silently dropping records based on current window size. elastic/filebeat#226
 - Fix direction field in published events. #300
+- Fix elasticsearch structured errors breaking error handling. #309
 
 ### Added
 

--- a/outputs/elasticsearch/client.go
+++ b/outputs/elasticsearch/client.go
@@ -174,8 +174,8 @@ func bulkCollectPublishFails(
 
 func itemStatus(m json.RawMessage) (int, string, error) {
 	var item map[string]struct {
-		Status int    `json:"status"`
-		Error  string `json:"error"`
+		Status int             `json:"status"`
+		Error  json.RawMessage `json:"error"`
 	}
 
 	err := json.Unmarshal(m, &item)
@@ -185,7 +185,10 @@ func itemStatus(m json.RawMessage) (int, string, error) {
 	}
 
 	for _, r := range item {
-		return r.Status, r.Error, nil
+		if len(r.Error) > 0 {
+			return r.Status, string(r.Error), nil
+		}
+		return r.Status, "", nil
 	}
 
 	err = ErrResponseRead

--- a/outputs/elasticsearch/client_test.go
+++ b/outputs/elasticsearch/client_test.go
@@ -1,0 +1,35 @@
+package elasticsearch
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestESNoErrorStatus(t *testing.T) {
+	response := json.RawMessage(`{"create": {"status": 200}}`)
+	code, msg, err := itemStatus(response)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 200, code)
+	assert.Equal(t, "", msg)
+}
+
+func TestES1StyleErrorStatus(t *testing.T) {
+	response := json.RawMessage(`{"create": {"status": 400, "error": "test error"}}`)
+	code, msg, err := itemStatus(response)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 400, code)
+	assert.Equal(t, `"test error"`, msg)
+}
+
+func TestES2StyleErrorStatus(t *testing.T) {
+	response := json.RawMessage(`{"create": {"status": 400, "error": {"reason": "test_error"}}}`)
+	code, msg, err := itemStatus(response)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 400, code)
+	assert.Equal(t, `{"reason": "test_error"}`, msg)
+}


### PR DESCRIPTION
fix parsing of per item error response message from bulk error handling code
supporting both Elasticsearch 1 (unstructured) and 2 (structured) error
reporting.