### PR TITLE
Call shutdown handler only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file based on the
 ### Backward Compatibility Breaks
 
 ### Bugfixes
+- Fix random panic on shutdown by calling shutdown handler only once. elastic/filebeat#204
 
 ### Added
 


### PR DESCRIPTION
Fixes two ocassions where shutdown handler is called twice. If beats shutdown
callback did not already protect itself from multiple shutdown signals (e.g. when
closing channels) shutdown might result in panic.

- Seems like on windows the shutdown handler might be called either by signal
  handler or by windows service handler. Here go-routines are used => there
  might be a race between service shutdown handler and signal handler

- If second signal is received we don't want to send another signal to the beat
  (even if it is not as harmfull), to keep contract with beat and libbeat
  more simple

resolves elastic/filebeat#204