### PR TITLE
Fix elasticsearch ping authentication fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file based on the
 ### Backward Compatibility Breaks
 
 ### Bugfixes
+- Fix credentials are not send when pinging an elasticsearch host. elastic/fileabeat#287
 
 ### Added
 

--- a/outputs/elasticsearch/client.go
+++ b/outputs/elasticsearch/client.go
@@ -241,14 +241,16 @@ func (conn *Connection) Connect(timeout time.Duration) error {
 }
 
 func (conn *Connection) Ping(timeout time.Duration) (bool, error) {
+	debug("ES Ping(url=%v, timeout=%v)", conn.URL, timeout)
+
 	conn.http.Timeout = timeout
-	resp, err := conn.http.Head(conn.URL)
+	status, _, err := conn.execRequest("HEAD", conn.URL, nil)
 	if err != nil {
+		debug("Ping request failed with: %v", err)
 		return false, err
 	}
-	defer closing(resp.Body)
 
-	status := resp.StatusCode
+	debug("Ping status code: %v", status)
 	return status < 300, nil
 }
 


### PR DESCRIPTION
Have ping use execRequest, so credentials are correctly set in request. Also
add some debug logging, for identifying reasons connection fail.

resolves elastic/filebeat#287