### PR TITLE
Set a default config file location for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file based on the
 ### Backward Compatibility Breaks
 
 ### Bugfixes
+- Fix default config file path for Windows. #341
 
 ### Added
 

--- a/cfgfile/cfgfile.go
+++ b/cfgfile/cfgfile.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"runtime"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -26,7 +28,13 @@ func ChangeDefaultCfgfileFlag(beatName string) error {
 	if cliflag == nil {
 		return fmt.Errorf("Flag -c not found")
 	}
-	cliflag.DefValue = fmt.Sprintf("/etc/%s/%s.yml", beatName, beatName)
+
+	if runtime.GOOS == "windows" {
+		cliflag.DefValue = fmt.Sprintf(`C:\Program Files\%s\%s.yml`,
+			strings.Title(beatName), beatName)
+	} else {
+		cliflag.DefValue = fmt.Sprintf("/etc/%s/%s.yml", beatName, beatName)
+	}
 	return cliflag.Value.Set(cliflag.DefValue)
 }
 


### PR DESCRIPTION
Fixes elastic/winlogbeat#2.

On Windows you will get this:
```
PS C:\Gopath\src\github.com\elastic\winlogbeat> .\build\bin\winlogbeat-windows-386.exe -h
Usage of C:\Gopath\src\github.com\elastic\winlogbeat\build\bin\winlogbeat-windows-386.exe:
  -N    Disable actual publishing for testing
  -c string
        Configuration file (default "C:\\Program Files\\Winlogbeat\\winlogbeat.yml")
  -configtest
        Test configuration and exit.
  -cpuprofile string
        Write cpu profile to file
  -d string
        Enable certain debug selectors
  -e    Log to stderr and disable syslog/file output
  -memprofile string
        Write memory profile to this file
  -v    Log at INFO level
  -version
        Print version and exit
```