### PR TITLE
Adding the ability to use a proxy server when connecting to ES

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -323,6 +323,15 @@ An HTTP path prefix that is prepended to the HTTP API calls. This is useful for
 the cases where Elasticsearch listens behind an HTTP reverse proxy that exports
 the API under a custom prefix.
 
+===== proxy_url
+
+The URL of the proxy to use when connecting to the Elasticsearch servers. The
+value may be either a complete URL or a "host[:port]", in which case the "http"
+scheme is assumed. If a value is not specified through the configuration file
+then proxy environment variables are used. See the
+https://golang.org/pkg/net/http/#ProxyFromEnvironment[golang documentation]
+for more information about the environment variables.
+
 ===== index
 
 The index root name to write events to. The default is the Beat name.

--- a/etc/libbeat.yml
+++ b/etc/libbeat.yml
@@ -31,6 +31,9 @@ output:
     # Optional HTTP Path
     #path: "/elasticsearch"
 
+    # Proxy server URL
+    # proxy_url: http://proxy:3128
+
     # The number of times a particular Elasticsearch index operation is attempted. If
     # the indexing operation doesn't succeed after this many retries, the events are
     # dropped. The default is 3.

--- a/outputs/elasticsearch/api_mock_test.go
+++ b/outputs/elasticsearch/api_mock_test.go
@@ -48,7 +48,7 @@ func TestOneHostSuccessResp(t *testing.T) {
 
 	server := ElasticsearchMock(200, expectedResp)
 
-	client := NewClient(server.URL, "", nil, "", "")
+	client := NewClient(server.URL, "", nil, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",
@@ -77,7 +77,7 @@ func TestOneHost500Resp(t *testing.T) {
 
 	server := ElasticsearchMock(http.StatusInternalServerError, []byte("Something wrong happened"))
 
-	client := NewClient(server.URL, "", nil, "", "")
+	client := NewClient(server.URL, "", nil, nil, "", "")
 	err := client.Connect(1 * time.Second)
 	if err != nil {
 		t.Fatalf("Failed to connect: %v", err)
@@ -112,7 +112,7 @@ func TestOneHost503Resp(t *testing.T) {
 
 	server := ElasticsearchMock(503, []byte("Something wrong happened"))
 
-	client := NewClient(server.URL, "", nil, "", "")
+	client := NewClient(server.URL, "", nil, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",

--- a/outputs/elasticsearch/api_test.go
+++ b/outputs/elasticsearch/api_test.go
@@ -35,7 +35,7 @@ func GetTestingElasticsearch() *Client {
 	var address = "http://" + GetEsHost() + ":" + GetEsPort()
 	username := os.Getenv("ES_USER")
 	pass := os.Getenv("ES_PASS")
-	return NewClient(address, "", nil, username, pass)
+	return NewClient(address, "", nil, nil, username, pass)
 }
 
 func GetValidQueryResult() QueryResult {

--- a/outputs/elasticsearch/bulkapi_mock_test.go
+++ b/outputs/elasticsearch/bulkapi_mock_test.go
@@ -40,7 +40,7 @@ func TestOneHostSuccessResp_Bulk(t *testing.T) {
 
 	server := ElasticsearchMock(200, expectedResp)
 
-	client := NewClient(server.URL, "", nil, "", "")
+	client := NewClient(server.URL, "", nil, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",
@@ -81,7 +81,7 @@ func TestOneHost500Resp_Bulk(t *testing.T) {
 
 	server := ElasticsearchMock(http.StatusInternalServerError, []byte("Something wrong happened"))
 
-	client := NewClient(server.URL, "", nil, "", "")
+	client := NewClient(server.URL, "", nil, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",
@@ -123,7 +123,7 @@ func TestOneHost503Resp_Bulk(t *testing.T) {
 
 	server := ElasticsearchMock(503, []byte("Something wrong happened"))
 
-	client := NewClient(server.URL, "", nil, "", "")
+	client := NewClient(server.URL, "", nil, nil, "", "")
 
 	params := map[string]string{
 		"refresh": "true",

--- a/outputs/elasticsearch/client.go
+++ b/outputs/elasticsearch/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/elastic/libbeat/common"
@@ -30,16 +31,24 @@ type Connection struct {
 }
 
 func NewClient(
-	url, index string, tls *tls.Config,
+	esURL, index string, proxyURL *url.URL, tls *tls.Config,
 	username, password string,
 ) *Client {
+	proxy := http.ProxyFromEnvironment
+	if proxyURL != nil {
+		proxy = http.ProxyURL(proxyURL)
+	}
+
 	client := &Client{
 		Connection{
-			URL:      url,
+			URL:      esURL,
 			Username: username,
 			Password: password,
 			http: &http.Client{
-				Transport: &http.Transport{TLSClientConfig: tls},
+				Transport: &http.Transport{
+					TLSClientConfig: tls,
+					Proxy:           proxy,
+				},
 			},
 		},
 		index,

--- a/outputs/elasticsearch/client_integration_test.go
+++ b/outputs/elasticsearch/client_integration_test.go
@@ -8,6 +8,10 @@ import (
 )
 
 func TestClientConnect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode because it requires ES")
+	}
+
 	client := GetTestingElasticsearch()
 	err := client.Connect(5 * time.Second)
 

--- a/outputs/logstash/logstash_integration_test.go
+++ b/outputs/logstash/logstash_integration_test.go
@@ -90,7 +90,7 @@ func esConnect(t *testing.T, index string) *esConnection {
 
 	username := os.Getenv("ES_USER")
 	password := os.Getenv("ES_PASS")
-	client := elasticsearch.NewClient(host, "", nil, username, password)
+	client := elasticsearch.NewClient(host, "", nil, nil, username, password)
 
 	// try to drop old index if left over from failed test
 	_, _, _ = client.Delete(index, "", "", nil) // ignore error

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -16,6 +16,7 @@ type MothershipConfig struct {
 	Protocol          string
 	Username          string
 	Password          string
+	ProxyURL          string `yaml:"proxy_url"`
 	Index             string
 	Path              string
 	Db                int


### PR DESCRIPTION
Fixed #338

If you don't want to merge this prior to reorganizing repos, I can easily open it up against the new repo. I tested it locally against a squid server, but it would be nice to add an integration test for it.